### PR TITLE
Add Yaru accents used in Ubuntu.

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,5 +93,95 @@ Tip: Use different color themes for different Flatpak apps. Add a different gtk.
             <td><p>Yaru-dark accent-color theme.</p></td>
             <td><a href="https://github.com/yellowgh0st" title="github">yellowgh0st</a></td>
         </tr>
+        <tr>
+            <td><a href="./themes/yaru-bark/gtk.css">yaru-bark</a></td>
+            <td><p>Yaru-bark accent-color theme.</p></td>
+            <td><a href="https://github.com/yellowgh0st" title="github">yellowgh0st</a></td>
+        </tr>
+        <tr>
+            <td><a href="./themes/yaru-bark-dark/gtk.css">yaru-bark-dark</a></td>
+            <td><p>Yaru-bark-dark accent-color theme.</p></td>
+            <td><a href="https://github.com/yellowgh0st" title="github">yellowgh0st</a></td>
+        </tr>
+        <tr>
+            <td><a href="./themes/yaru-blue/gtk.css">yaru-blue</a></td>
+            <td><p>Yaru-blue accent-color theme.</p></td>
+            <td><a href="https://github.com/yellowgh0st" title="github">yellowgh0st</a></td>
+        </tr>
+        <tr>
+            <td><a href="./themes/yaru-blue-dark/gtk.css">yaru-blue-dark</a></td>
+            <td><p>Yaru-blue-dark accent-color theme.</p></td>
+            <td><a href="https://github.com/yellowgh0st" title="github">yellowgh0st</a></td>
+        </tr>
+        <tr>
+            <td><a href="./themes/yaru-magenta/gtk.css">yaru-magenta</a></td>
+            <td><p>Yaru-magenta accent-color theme.</p></td>
+            <td><a href="https://github.com/yellowgh0st" title="github">yellowgh0st</a></td>
+        </tr>
+        <tr>
+            <td><a href="./themes/yaru-magenta-dark/gtk.css">yaru-magenta-dark</a></td>
+            <td><p>Yaru-magenta-dark accent-color theme.</p></td>
+            <td><a href="https://github.com/yellowgh0st" title="github">yellowgh0st</a></td>
+        </tr>
+        <tr>
+            <td><a href="./themes/yaru-olive/gtk.css">yaru-olive</a></td>
+            <td><p>Yaru-olive accent-color theme.</p></td>
+            <td><a href="https://github.com/yellowgh0st" title="github">yellowgh0st</a></td>
+        </tr>
+        <tr>
+            <td><a href="./themes/yaru-olive-dark/gtk.css">yaru-olive-dark</a></td>
+            <td><p>Yaru-olive-dark accent-color theme.</p></td>
+            <td><a href="https://github.com/yellowgh0st" title="github">yellowgh0st</a></td>
+        </tr>
+        <tr>
+            <td><a href="./themes/yaru-prussiangreen/gtk.css">yaru-prussiangreen</a></td>
+            <td><p>Yaru-prussiangreen accent-color theme.</p></td>
+            <td><a href="https://github.com/yellowgh0st" title="github">yellowgh0st</a></td>
+        </tr>
+        <tr>
+            <td><a href="./themes/yaru-prussiangreen-dark/gtk.css">yaru-prussiangreen-dark</a></td>
+            <td><p>Yaru-prussiangreen-dark accent-color theme.</p></td>
+            <td><a href="https://github.com/yellowgh0st" title="github">yellowgh0st</a></td>
+        </tr>
+        <tr>
+            <td><a href="./themes/yaru-purple/gtk.css">yaru-purple</a></td>
+            <td><p>Yaru-purple accent-color theme.</p></td>
+            <td><a href="https://github.com/yellowgh0st" title="github">yellowgh0st</a></td>
+        </tr>
+        <tr>
+            <td><a href="./themes/yaru-purple-dark/gtk.css">yaru-purple-dark</a></td>
+            <td><p>Yaru-purple-dark accent-color theme.</p></td>
+            <td><a href="https://github.com/yellowgh0st" title="github">yellowgh0st</a></td>
+        </tr>
+        <tr>
+            <td><a href="./themes/yaru-red/gtk.css">yaru-red</a></td>
+            <td><p>Yaru-red accent-color theme.</p></td>
+            <td><a href="https://github.com/yellowgh0st" title="github">yellowgh0st</a></td>
+        </tr>
+        <tr>
+            <td><a href="./themes/yaru-red-dark/gtk.css">yaru-red-dark</a></td>
+            <td><p>Yaru-red-dark accent-color theme.</p></td>
+            <td><a href="https://github.com/yellowgh0st" title="github">yellowgh0st</a></td>
+        </tr>
+        <tr>
+            <td><a href="./themes/yaru-sage/gtk.css">yaru-sage</a></td>
+            <td><p>Yaru-sage accent-color theme.</p></td>
+            <td><a href="https://github.com/yellowgh0st" title="github">yellowgh0st</a></td>
+        </tr>
+        <tr>
+            <td><a href="./themes/yaru-sage-dark/gtk.css">yaru-sage-dark</a></td>
+            <td><p>Yaru-sage-dark accent-color theme.</p></td>
+            <td><a href="https://github.com/yellowgh0st" title="github">yellowgh0st</a></td>
+        </tr>
+        <tr>
+            <td><a href="./themes/yaru-viridian/gtk.css">yaru-viridian</a></td>
+            <td><p>Yaru-viridian accent-color theme.</p></td>
+            <td><a href="https://github.com/yellowgh0st" title="github">yellowgh0st</a></td>
+        </tr>
+        <tr>
+            <td><a href="./themes/yaru-sage-dark/gtk.css">yaru-viridian-dark</a></td>
+            <td><p>Yaru-viridian-dark accent-color theme.</p></td>
+            <td><a href="https://github.com/yellowgh0st" title="github">yellowgh0st</a></td>
+        </tr>
     </table>
 </div>

--- a/themes/yaru-bark-dark/_colors.scss
+++ b/themes/yaru-bark-dark/_colors.scss
@@ -1,0 +1,35 @@
+$accent_bg_color: gtkcolor(accent_bg_color);
+$accent_fg_color: gtkcolor(accent_fg_color);
+$accent_color: gtkcolor(accent_color);
+
+$destructive_bg_color: gtkcolor(destructive_bg_color);
+$destructive_fg_color: gtkcolor(destructive_fg_color);
+$destructive_color: gtkcolor(destructive_color);
+
+$success_bg_color: gtkcolor(success_bg_color);
+$success_fg_color: gtkcolor(success_fg_color);
+$success_color: gtkcolor(success_color);
+
+$warning_bg_color: gtkcolor(warning_bg_color);
+$warning_fg_color: gtkcolor(warning_fg_color);
+$warning_color: gtkcolor(warning_color);
+
+$error_bg_color: gtkcolor(error_bg_color);
+$error_fg_color: gtkcolor(error_fg_color);
+$error_color: gtkcolor(error_color);
+
+$window_bg_color: gtkcolor(window_bg_color);
+$window_fg_color: gtkcolor(window_fg_color);
+
+$view_bg_color: gtkcolor(view_bg_color);
+$view_fg_color: gtkcolor(view_fg_color);
+
+$headerbar_bg_color: gtkcolor(headerbar_bg_color);
+$headerbar_fg_color: gtkcolor(headerbar_fg_color);
+$headerbar_backdrop_color: gtkcolor(headerbar_backdrop_color);
+
+$card_bg_color: gtkcolor(card_bg_color);
+$card_fg_color: gtkcolor(card_fg_color);
+
+$popover_bg_color: gtkcolor(popover_bg_color);
+$popover_fg_color: gtkcolor(popover_fg_color);

--- a/themes/yaru-bark-dark/_defaults.scss
+++ b/themes/yaru-bark-dark/_defaults.scss
@@ -1,0 +1,53 @@
+/* GTK NAMED COLORS
+   ----------------
+   use responsibly! */
+
+// Sass thinks we're using the colors in the variables as strings and may shoot
+// warning, it's innocuous and can be defeated by using #{$var}.
+
+// These are the colors apps are can override. We define the defaults here and
+// define variables for them in _colors.scss
+
+// The main accent color and the matching text value
+@define-color accent_bg_color @yaru_accent_bg_color;
+@define-color accent_fg_color @light_1;
+@define-color accent_color @yaru_accent_bg_color;
+
+// destructive-action buttons
+@define-color destructive_bg_color @red_4;
+@define-color destructive_fg_color @light_1;
+@define-color destructive_color @red_4;
+
+// Levelbars, entries, labels and infobars. These don't need text colors
+@define-color success_bg_color @green_4;
+@define-color success_fg_color @light_1;
+@define-color success_color @green_4;
+
+@define-color warning_bg_color @yellow_5;
+@define-color warning_fg_color @light_1;
+@define-color warning_color @yellow_5;
+
+@define-color error_bg_color @red_4;
+@define-color error_fg_color @light_1;
+@define-color error_color @red_4;
+
+// Window
+@define-color window_bg_color #{if($variant == 'light', #fafafa, lighten(#181818, 8%))};
+@define-color window_fg_color #{if($variant=='light', '@dark_3', '@light_2')};
+
+// Views - e.g. text view or tree view
+@define-color view_bg_color #{if($variant == 'light', #ffffff, #1e1e1e)};
+@define-color view_fg_color #{if($variant == 'light', #000000, #ffffff)};
+
+// Header bar, search bar, tab bar
+@define-color headerbar_bg_color #{if($variant == 'light', #ebebeb, #303030)};
+@define-color headerbar_fg_color #{if($variant == 'light', transparentize(black, .2), white)};
+@define-color headerbar_backdrop_color @window_bg_color;
+
+// Cards, boxed lists
+@define-color card_bg_color #{if($variant == 'light', #ffffff, transparentize(white, .92))};
+@define-color card_fg_color #{if($variant == 'light', transparentize(black, .2), white)};
+
+// Popovers
+@define-color popover_bg_color #{if($variant == 'light', #ffffff, #383838)};
+@define-color popover_fg_color #{if($variant == 'light', transparentize(black, .2), white)};

--- a/themes/yaru-bark-dark/_functions.scss
+++ b/themes/yaru-bark-dark/_functions.scss
@@ -1,0 +1,16 @@
+@function gtkalpha($c,$a) {
+  @return unquote("alpha(#{$c},#{$a})");
+}
+
+@function gtkmix($c1,$c2,$r) {
+  $ratio: 1 -  $r / 100%; // match SCSS mix()
+  @return unquote("mix(#{$c1},#{$c2},#{$ratio})");
+}
+
+@function gtkshade($c,$s) {
+  @return unquote("shade(#{$c},#{$s})");
+}
+
+@function gtkcolor($c) {
+  @return unquote("@#{$c}");
+}

--- a/themes/yaru-bark-dark/_palette.scss
+++ b/themes/yaru-bark-dark/_palette.scss
@@ -1,0 +1,110 @@
+$blue_1: #75d3f4;
+$blue_2: #47c4f1;
+$blue_3: #19B6EE; // Yaru blue
+$blue_4: #007aa6; // Yaru linkblue
+$blue_5: #335280; // Yaru darkblue
+$green_1: #5AED70;
+$green_2: #47D35C;
+$green_3: #34B948;
+$green_4: #219E34;
+$green_5: #0e8420; // Yaru green
+$yellow_1: #FCCD87;
+$yellow_2: #FBC16A;
+$yellow_3: #FBB44C;
+$yellow_4: #FAA82F;
+$yellow_5: #F99B11; // Yaru yellow
+$orange_1: #F29879;
+$orange_2: #F08763;
+$orange_3: #ED764D;
+$orange_4: #EB6536;
+$orange_5: #E95420; // Yaru orange
+$red_1: #EA485C;
+$red_2: #DE374C;
+$red_3: #D3273B;
+$red_4: #c7162b; // Yaru red
+$red_5: #a91224;
+$purple_1: #924D8B; // Yaru aubergine
+$purple_2: #762572; // Yaru purple
+$purple_3: #77216F; // Yaru light aubergine
+$purple_4: #5E2750; // Yaru mid aubergine
+$purple_5: #2C001E; // Yaru dark aubergine
+$brown_1: #E1B289;
+$brown_2: #C5976E;
+$brown_3: #AA7B53;
+$brown_4: #8E6038;
+$brown_5: #72441D;
+$light_1: #FFFFFF;
+$light_2: #F7F7F7; // Yaru porcelain
+$light_3: #CCC; // Yaru silk
+$light_4: #AEA79F; // Yaru warm gray
+$light_5: #878787; // Yaru ash
+$dark_1: #666666; // Yaru graphite
+$dark_2: #5D5D5D; // Yaru slate
+$dark_3: #3D3D3D; // Yaru inkstone
+$dark_4: #181818; // Yaru jet
+$dark_5: #000000;
+
+// Ubuntu accent colors
+$default: $orange_5;
+$bark: #787859;
+$sage: #657B69;
+$olive: #4B8501;
+$viridian: #03875B;
+$prussiangreen: #308280;
+$blue: #0073E5;
+$purple: #7764D8;
+$magenta: #B34CB3;
+$red: #DA3450;
+
+$yaru_accent_bg_color: $bark !default;
+@define-color yaru_accent_bg_color #{$yaru_accent_bg_color};
+
+
+// Sass thinks we're using the colors in the variables as strings and may shoot
+// warning, it's innocuous and can be defeated by using #{$var}.
+
+@define-color blue_1 #{$blue_1};
+@define-color blue_2 #{$blue_2};
+@define-color blue_3 #{$blue_3};
+@define-color blue_4 #{$blue_4};
+@define-color blue_5 #{$blue_5};
+@define-color green_1 #{$green_1};
+@define-color green_2 #{$green_2};
+@define-color green_3 #{$green_3};
+@define-color green_4 #{$green_4};
+@define-color green_5 #{$green_5};
+@define-color yellow_1 #{$yellow_1};
+@define-color yellow_2 #{$yellow_2};
+@define-color yellow_3 #{$yellow_3};
+@define-color yellow_4 #{$yellow_4};
+@define-color yellow_5 #{$yellow_5};
+@define-color orange_1 #{$orange_1};
+@define-color orange_2 #{$orange_2};
+@define-color orange_3 #{$orange_3};
+@define-color orange_4 #{$orange_4};
+@define-color orange_5 #{$orange_5};
+@define-color red_1 #{$red_1};
+@define-color red_2 #{$red_2};
+@define-color red_3 #{$red_3};
+@define-color red_4 #{$red_4};
+@define-color red_5 #{$red_5};
+@define-color purple_1 #{$purple_1};
+@define-color purple_2 #{$purple_2};
+@define-color purple_3 #{$purple_3};
+@define-color purple_4 #{$purple_4};
+@define-color purple_5 #{$purple_5};
+@define-color brown_1 #{$brown_1};
+@define-color brown_2 #{$brown_2};
+@define-color brown_3 #{$brown_3};
+@define-color brown_4 #{$brown_4};
+@define-color brown_5 #{$brown_5};
+@define-color light_1 #{$light_1};
+@define-color light_2 #{$light_2};
+@define-color light_3 #{$light_3};
+@define-color light_4 #{$light_4};
+@define-color light_5 #{$light_5};
+@define-color dark_1 #{$dark_1};
+@define-color dark_2 #{$dark_2};
+@define-color dark_3 #{$dark_3};
+@define-color dark_4 #{$dark_4};
+@define-color dark_5 #{$dark_5};

--- a/themes/yaru-bark-dark/_tweaks.scss
+++ b/themes/yaru-bark-dark/_tweaks.scss
@@ -1,0 +1,73 @@
+// Reducing the amount of the palette's background colors to two
+.sidebar {
+	background-color: $window_bg_color;
+}
+
+// Entries drown if drawn on widgets with $base_color
+// Fixing this at least for notebooks, since entries on tabs is a common pattern
+// Remove this when upstream makes entries have a light border in the dark theme
+@if $variant== "dark" {
+	notebook entry {
+			background-color: gtkmix($view_bg_color, black, 98%);
+	}
+}
+
+// Fix popover wiggling effect (see #2903)
+popover.menu {
+	check,
+	radio {
+			transition: none;
+	}
+}
+
+// Use our own palette for high and not empty levelbar
+levelbar {
+	> trough {
+			> block {
+					&.high,
+					&:not(.empty) {
+							background-color: $success_color;
+					}
+			}
+	}
+}
+
+// Green suggested buttons
+%button,
+button {
+	&.suggested-action {
+			color: $success_fg_color;
+
+			&,
+			&:checked {
+					&:not(.flat) {
+							background-color: $success_bg_color;
+					}
+			}
+	}
+
+	&.flat {
+			&.suggested-action {
+					color: $success_color;
+			}
+	}
+}
+
+splitbutton {
+	&.suggested-action {
+			> button, > menubutton > button {
+					color: $success_fg_color;
+	
+					&, &:checked {
+							background-color: $success_bg_color;
+					}
+			}
+	}
+}
+
+%button,
+button,
+%link,
+link {
+	font-weight: normal;
+}

--- a/themes/yaru-bark-dark/gtk-dark.scss
+++ b/themes/yaru-bark-dark/gtk-dark.scss
@@ -1,0 +1,13 @@
+// General guidelines:
+// - very unlikely you want to edit something else than _common.scss
+// - keep the number of defined colors to a minimum, use the color blending functions if
+//   you need a subtle shade
+// - if you need to inverse a color function use the @if directive to match for dark $variant
+
+$variant: 'dark';
+
+@import 'palette';
+@import 'defaults';
+@import 'functions';
+@import 'colors';
+@import 'tweaks';

--- a/themes/yaru-bark-dark/gtk.css
+++ b/themes/yaru-bark-dark/gtk.css
@@ -1,0 +1,121 @@
+@define-color yaru_accent_bg_color #787859;
+@define-color blue_1 #75d3f4;
+@define-color blue_2 #47c4f1;
+@define-color blue_3 #19B6EE;
+@define-color blue_4 #007aa6;
+@define-color blue_5 #335280;
+@define-color green_1 #5AED70;
+@define-color green_2 #47D35C;
+@define-color green_3 #34B948;
+@define-color green_4 #219E34;
+@define-color green_5 #0e8420;
+@define-color yellow_1 #FCCD87;
+@define-color yellow_2 #FBC16A;
+@define-color yellow_3 #FBB44C;
+@define-color yellow_4 #FAA82F;
+@define-color yellow_5 #F99B11;
+@define-color orange_1 #F29879;
+@define-color orange_2 #F08763;
+@define-color orange_3 #ED764D;
+@define-color orange_4 #EB6536;
+@define-color orange_5 #E95420;
+@define-color red_1 #EA485C;
+@define-color red_2 #DE374C;
+@define-color red_3 #D3273B;
+@define-color red_4 #c7162b;
+@define-color red_5 #a91224;
+@define-color purple_1 #924D8B;
+@define-color purple_2 #762572;
+@define-color purple_3 #77216F;
+@define-color purple_4 #5E2750;
+@define-color purple_5 #2C001E;
+@define-color brown_1 #E1B289;
+@define-color brown_2 #C5976E;
+@define-color brown_3 #AA7B53;
+@define-color brown_4 #8E6038;
+@define-color brown_5 #72441D;
+@define-color light_1 #FFFFFF;
+@define-color light_2 #F7F7F7;
+@define-color light_3 #CCC;
+@define-color light_4 #AEA79F;
+@define-color light_5 #878787;
+@define-color dark_1 #666666;
+@define-color dark_2 #5D5D5D;
+@define-color dark_3 #3D3D3D;
+@define-color dark_4 #181818;
+@define-color dark_5 #000000;
+/* GTK NAMED COLORS
+   ----------------
+   use responsibly! */
+@define-color accent_bg_color @yaru_accent_bg_color;
+@define-color accent_fg_color @light_1;
+@define-color accent_color @yaru_accent_bg_color;
+@define-color destructive_bg_color @red_4;
+@define-color destructive_fg_color @light_1;
+@define-color destructive_color @red_4;
+@define-color success_bg_color @green_4;
+@define-color success_fg_color @light_1;
+@define-color success_color @green_4;
+@define-color warning_bg_color @yellow_5;
+@define-color warning_fg_color @light_1;
+@define-color warning_color @yellow_5;
+@define-color error_bg_color @red_4;
+@define-color error_fg_color @light_1;
+@define-color error_color @red_4;
+@define-color window_bg_color #2c2c2c;
+@define-color window_fg_color @light_2;
+@define-color view_bg_color #1e1e1e;
+@define-color view_fg_color #ffffff;
+@define-color headerbar_bg_color #303030;
+@define-color headerbar_fg_color white;
+@define-color headerbar_backdrop_color @window_bg_color;
+@define-color card_bg_color rgba(255, 255, 255, 0.08);
+@define-color card_fg_color white;
+@define-color popover_bg_color #383838;
+@define-color popover_fg_color white;
+.sidebar {
+  background-color: @window_bg_color;
+}
+
+notebook entry {
+  background-color: mix(@view_bg_color,black,0.02);
+}
+
+popover.menu check,
+popover.menu radio {
+  transition: none;
+}
+
+levelbar > trough > block.high, levelbar > trough > block:not(.empty) {
+  background-color: @success_color;
+}
+
+
+button.suggested-action {
+  color: @success_fg_color;
+}
+
+
+button.suggested-action:not(.flat),
+button.suggested-action:checked:not(.flat) {
+  background-color: @success_bg_color;
+}
+
+
+button.flat.suggested-action {
+  color: @success_color;
+}
+
+splitbutton.suggested-action > button, splitbutton.suggested-action > menubutton > button {
+  color: @success_fg_color;
+}
+
+splitbutton.suggested-action > button, splitbutton.suggested-action > button:checked, splitbutton.suggested-action > menubutton > button, splitbutton.suggested-action > menubutton > button:checked {
+  background-color: @success_bg_color;
+}
+
+
+button,
+link {
+  font-weight: normal;
+}

--- a/themes/yaru-bark-dark/gtk.scss
+++ b/themes/yaru-bark-dark/gtk.scss
@@ -1,0 +1,14 @@
+// General guidelines:
+// - very unlikely you want to edit something else than _common.scss
+// - keep the number of defined colors to a minimum, use the color blending functions if
+//   you need a subtle shade
+// - if you need to inverse a color function use the @if directive to match for dark $variant
+
+$variant: 'light';
+
+@import 'palette';
+@import 'defaults';
+@import 'functions';
+@import 'colors';
+@import 'tweaks';
+

--- a/themes/yaru-bark-dark/parse-sass.sh
+++ b/themes/yaru-bark-dark/parse-sass.sh
@@ -1,0 +1,12 @@
+#! /bin/bash
+
+if [ ! "$(which sassc 2> /dev/null)" ]; then
+   echo sassc needs to be installed to generate the css.
+   exit 1
+fi
+
+SASSC_OPT="-M -t expanded"
+
+echo Generating the css...
+
+sassc $SASSC_OPT gtk-dark.scss gtk.css

--- a/themes/yaru-bark/_colors.scss
+++ b/themes/yaru-bark/_colors.scss
@@ -1,0 +1,35 @@
+$accent_bg_color: gtkcolor(accent_bg_color);
+$accent_fg_color: gtkcolor(accent_fg_color);
+$accent_color: gtkcolor(accent_color);
+
+$destructive_bg_color: gtkcolor(destructive_bg_color);
+$destructive_fg_color: gtkcolor(destructive_fg_color);
+$destructive_color: gtkcolor(destructive_color);
+
+$success_bg_color: gtkcolor(success_bg_color);
+$success_fg_color: gtkcolor(success_fg_color);
+$success_color: gtkcolor(success_color);
+
+$warning_bg_color: gtkcolor(warning_bg_color);
+$warning_fg_color: gtkcolor(warning_fg_color);
+$warning_color: gtkcolor(warning_color);
+
+$error_bg_color: gtkcolor(error_bg_color);
+$error_fg_color: gtkcolor(error_fg_color);
+$error_color: gtkcolor(error_color);
+
+$window_bg_color: gtkcolor(window_bg_color);
+$window_fg_color: gtkcolor(window_fg_color);
+
+$view_bg_color: gtkcolor(view_bg_color);
+$view_fg_color: gtkcolor(view_fg_color);
+
+$headerbar_bg_color: gtkcolor(headerbar_bg_color);
+$headerbar_fg_color: gtkcolor(headerbar_fg_color);
+$headerbar_backdrop_color: gtkcolor(headerbar_backdrop_color);
+
+$card_bg_color: gtkcolor(card_bg_color);
+$card_fg_color: gtkcolor(card_fg_color);
+
+$popover_bg_color: gtkcolor(popover_bg_color);
+$popover_fg_color: gtkcolor(popover_fg_color);

--- a/themes/yaru-bark/_defaults.scss
+++ b/themes/yaru-bark/_defaults.scss
@@ -1,0 +1,53 @@
+/* GTK NAMED COLORS
+   ----------------
+   use responsibly! */
+
+// Sass thinks we're using the colors in the variables as strings and may shoot
+// warning, it's innocuous and can be defeated by using #{$var}.
+
+// These are the colors apps are can override. We define the defaults here and
+// define variables for them in _colors.scss
+
+// The main accent color and the matching text value
+@define-color accent_bg_color @yaru_accent_bg_color;
+@define-color accent_fg_color @light_1;
+@define-color accent_color @yaru_accent_bg_color;
+
+// destructive-action buttons
+@define-color destructive_bg_color @red_4;
+@define-color destructive_fg_color @light_1;
+@define-color destructive_color @red_4;
+
+// Levelbars, entries, labels and infobars. These don't need text colors
+@define-color success_bg_color @green_4;
+@define-color success_fg_color @light_1;
+@define-color success_color @green_4;
+
+@define-color warning_bg_color @yellow_5;
+@define-color warning_fg_color @light_1;
+@define-color warning_color @yellow_5;
+
+@define-color error_bg_color @red_4;
+@define-color error_fg_color @light_1;
+@define-color error_color @red_4;
+
+// Window
+@define-color window_bg_color #{if($variant == 'light', #fafafa, lighten(#181818, 8%))};
+@define-color window_fg_color #{if($variant=='light', '@dark_3', '@light_2')};
+
+// Views - e.g. text view or tree view
+@define-color view_bg_color #{if($variant == 'light', #ffffff, #1e1e1e)};
+@define-color view_fg_color #{if($variant == 'light', #000000, #ffffff)};
+
+// Header bar, search bar, tab bar
+@define-color headerbar_bg_color #{if($variant == 'light', #ebebeb, #303030)};
+@define-color headerbar_fg_color #{if($variant == 'light', transparentize(black, .2), white)};
+@define-color headerbar_backdrop_color @window_bg_color;
+
+// Cards, boxed lists
+@define-color card_bg_color #{if($variant == 'light', #ffffff, transparentize(white, .92))};
+@define-color card_fg_color #{if($variant == 'light', transparentize(black, .2), white)};
+
+// Popovers
+@define-color popover_bg_color #{if($variant == 'light', #ffffff, #383838)};
+@define-color popover_fg_color #{if($variant == 'light', transparentize(black, .2), white)};

--- a/themes/yaru-bark/_functions.scss
+++ b/themes/yaru-bark/_functions.scss
@@ -1,0 +1,16 @@
+@function gtkalpha($c,$a) {
+  @return unquote("alpha(#{$c},#{$a})");
+}
+
+@function gtkmix($c1,$c2,$r) {
+  $ratio: 1 -  $r / 100%; // match SCSS mix()
+  @return unquote("mix(#{$c1},#{$c2},#{$ratio})");
+}
+
+@function gtkshade($c,$s) {
+  @return unquote("shade(#{$c},#{$s})");
+}
+
+@function gtkcolor($c) {
+  @return unquote("@#{$c}");
+}

--- a/themes/yaru-bark/_palette.scss
+++ b/themes/yaru-bark/_palette.scss
@@ -1,0 +1,110 @@
+$blue_1: #75d3f4;
+$blue_2: #47c4f1;
+$blue_3: #19B6EE; // Yaru blue
+$blue_4: #007aa6; // Yaru linkblue
+$blue_5: #335280; // Yaru darkblue
+$green_1: #5AED70;
+$green_2: #47D35C;
+$green_3: #34B948;
+$green_4: #219E34;
+$green_5: #0e8420; // Yaru green
+$yellow_1: #FCCD87;
+$yellow_2: #FBC16A;
+$yellow_3: #FBB44C;
+$yellow_4: #FAA82F;
+$yellow_5: #F99B11; // Yaru yellow
+$orange_1: #F29879;
+$orange_2: #F08763;
+$orange_3: #ED764D;
+$orange_4: #EB6536;
+$orange_5: #E95420; // Yaru orange
+$red_1: #EA485C;
+$red_2: #DE374C;
+$red_3: #D3273B;
+$red_4: #c7162b; // Yaru red
+$red_5: #a91224;
+$purple_1: #924D8B; // Yaru aubergine
+$purple_2: #762572; // Yaru purple
+$purple_3: #77216F; // Yaru light aubergine
+$purple_4: #5E2750; // Yaru mid aubergine
+$purple_5: #2C001E; // Yaru dark aubergine
+$brown_1: #E1B289;
+$brown_2: #C5976E;
+$brown_3: #AA7B53;
+$brown_4: #8E6038;
+$brown_5: #72441D;
+$light_1: #FFFFFF;
+$light_2: #F7F7F7; // Yaru porcelain
+$light_3: #CCC; // Yaru silk
+$light_4: #AEA79F; // Yaru warm gray
+$light_5: #878787; // Yaru ash
+$dark_1: #666666; // Yaru graphite
+$dark_2: #5D5D5D; // Yaru slate
+$dark_3: #3D3D3D; // Yaru inkstone
+$dark_4: #181818; // Yaru jet
+$dark_5: #000000;
+
+// Ubuntu accent colors
+$default: $orange_5;
+$bark: #787859;
+$sage: #657B69;
+$olive: #4B8501;
+$viridian: #03875B;
+$prussiangreen: #308280;
+$blue: #0073E5;
+$purple: #7764D8;
+$magenta: #B34CB3;
+$red: #DA3450;
+
+$yaru_accent_bg_color: $bark !default;
+@define-color yaru_accent_bg_color #{$yaru_accent_bg_color};
+
+
+// Sass thinks we're using the colors in the variables as strings and may shoot
+// warning, it's innocuous and can be defeated by using #{$var}.
+
+@define-color blue_1 #{$blue_1};
+@define-color blue_2 #{$blue_2};
+@define-color blue_3 #{$blue_3};
+@define-color blue_4 #{$blue_4};
+@define-color blue_5 #{$blue_5};
+@define-color green_1 #{$green_1};
+@define-color green_2 #{$green_2};
+@define-color green_3 #{$green_3};
+@define-color green_4 #{$green_4};
+@define-color green_5 #{$green_5};
+@define-color yellow_1 #{$yellow_1};
+@define-color yellow_2 #{$yellow_2};
+@define-color yellow_3 #{$yellow_3};
+@define-color yellow_4 #{$yellow_4};
+@define-color yellow_5 #{$yellow_5};
+@define-color orange_1 #{$orange_1};
+@define-color orange_2 #{$orange_2};
+@define-color orange_3 #{$orange_3};
+@define-color orange_4 #{$orange_4};
+@define-color orange_5 #{$orange_5};
+@define-color red_1 #{$red_1};
+@define-color red_2 #{$red_2};
+@define-color red_3 #{$red_3};
+@define-color red_4 #{$red_4};
+@define-color red_5 #{$red_5};
+@define-color purple_1 #{$purple_1};
+@define-color purple_2 #{$purple_2};
+@define-color purple_3 #{$purple_3};
+@define-color purple_4 #{$purple_4};
+@define-color purple_5 #{$purple_5};
+@define-color brown_1 #{$brown_1};
+@define-color brown_2 #{$brown_2};
+@define-color brown_3 #{$brown_3};
+@define-color brown_4 #{$brown_4};
+@define-color brown_5 #{$brown_5};
+@define-color light_1 #{$light_1};
+@define-color light_2 #{$light_2};
+@define-color light_3 #{$light_3};
+@define-color light_4 #{$light_4};
+@define-color light_5 #{$light_5};
+@define-color dark_1 #{$dark_1};
+@define-color dark_2 #{$dark_2};
+@define-color dark_3 #{$dark_3};
+@define-color dark_4 #{$dark_4};
+@define-color dark_5 #{$dark_5};

--- a/themes/yaru-bark/_tweaks.scss
+++ b/themes/yaru-bark/_tweaks.scss
@@ -1,0 +1,73 @@
+// Reducing the amount of the palette's background colors to two
+.sidebar {
+	background-color: $window_bg_color;
+}
+
+// Entries drown if drawn on widgets with $base_color
+// Fixing this at least for notebooks, since entries on tabs is a common pattern
+// Remove this when upstream makes entries have a light border in the dark theme
+@if $variant== "dark" {
+	notebook entry {
+			background-color: gtkmix($view_bg_color, black, 98%);
+	}
+}
+
+// Fix popover wiggling effect (see #2903)
+popover.menu {
+	check,
+	radio {
+			transition: none;
+	}
+}
+
+// Use our own palette for high and not empty levelbar
+levelbar {
+	> trough {
+			> block {
+					&.high,
+					&:not(.empty) {
+							background-color: $success_color;
+					}
+			}
+	}
+}
+
+// Green suggested buttons
+%button,
+button {
+	&.suggested-action {
+			color: $success_fg_color;
+
+			&,
+			&:checked {
+					&:not(.flat) {
+							background-color: $success_bg_color;
+					}
+			}
+	}
+
+	&.flat {
+			&.suggested-action {
+					color: $success_color;
+			}
+	}
+}
+
+splitbutton {
+	&.suggested-action {
+			> button, > menubutton > button {
+					color: $success_fg_color;
+	
+					&, &:checked {
+							background-color: $success_bg_color;
+					}
+			}
+	}
+}
+
+%button,
+button,
+%link,
+link {
+	font-weight: normal;
+}

--- a/themes/yaru-bark/gtk-dark.scss
+++ b/themes/yaru-bark/gtk-dark.scss
@@ -1,0 +1,13 @@
+// General guidelines:
+// - very unlikely you want to edit something else than _common.scss
+// - keep the number of defined colors to a minimum, use the color blending functions if
+//   you need a subtle shade
+// - if you need to inverse a color function use the @if directive to match for dark $variant
+
+$variant: 'dark';
+
+@import 'palette';
+@import 'defaults';
+@import 'functions';
+@import 'colors';
+@import 'tweaks';

--- a/themes/yaru-bark/gtk.css
+++ b/themes/yaru-bark/gtk.css
@@ -1,0 +1,117 @@
+@define-color yaru_accent_bg_color #787859;
+@define-color blue_1 #75d3f4;
+@define-color blue_2 #47c4f1;
+@define-color blue_3 #19B6EE;
+@define-color blue_4 #007aa6;
+@define-color blue_5 #335280;
+@define-color green_1 #5AED70;
+@define-color green_2 #47D35C;
+@define-color green_3 #34B948;
+@define-color green_4 #219E34;
+@define-color green_5 #0e8420;
+@define-color yellow_1 #FCCD87;
+@define-color yellow_2 #FBC16A;
+@define-color yellow_3 #FBB44C;
+@define-color yellow_4 #FAA82F;
+@define-color yellow_5 #F99B11;
+@define-color orange_1 #F29879;
+@define-color orange_2 #F08763;
+@define-color orange_3 #ED764D;
+@define-color orange_4 #EB6536;
+@define-color orange_5 #E95420;
+@define-color red_1 #EA485C;
+@define-color red_2 #DE374C;
+@define-color red_3 #D3273B;
+@define-color red_4 #c7162b;
+@define-color red_5 #a91224;
+@define-color purple_1 #924D8B;
+@define-color purple_2 #762572;
+@define-color purple_3 #77216F;
+@define-color purple_4 #5E2750;
+@define-color purple_5 #2C001E;
+@define-color brown_1 #E1B289;
+@define-color brown_2 #C5976E;
+@define-color brown_3 #AA7B53;
+@define-color brown_4 #8E6038;
+@define-color brown_5 #72441D;
+@define-color light_1 #FFFFFF;
+@define-color light_2 #F7F7F7;
+@define-color light_3 #CCC;
+@define-color light_4 #AEA79F;
+@define-color light_5 #878787;
+@define-color dark_1 #666666;
+@define-color dark_2 #5D5D5D;
+@define-color dark_3 #3D3D3D;
+@define-color dark_4 #181818;
+@define-color dark_5 #000000;
+/* GTK NAMED COLORS
+   ----------------
+   use responsibly! */
+@define-color accent_bg_color @yaru_accent_bg_color;
+@define-color accent_fg_color @light_1;
+@define-color accent_color @yaru_accent_bg_color;
+@define-color destructive_bg_color @red_4;
+@define-color destructive_fg_color @light_1;
+@define-color destructive_color @red_4;
+@define-color success_bg_color @green_4;
+@define-color success_fg_color @light_1;
+@define-color success_color @green_4;
+@define-color warning_bg_color @yellow_5;
+@define-color warning_fg_color @light_1;
+@define-color warning_color @yellow_5;
+@define-color error_bg_color @red_4;
+@define-color error_fg_color @light_1;
+@define-color error_color @red_4;
+@define-color window_bg_color #fafafa;
+@define-color window_fg_color @dark_3;
+@define-color view_bg_color #ffffff;
+@define-color view_fg_color #000000;
+@define-color headerbar_bg_color #ebebeb;
+@define-color headerbar_fg_color rgba(0, 0, 0, 0.8);
+@define-color headerbar_backdrop_color @window_bg_color;
+@define-color card_bg_color #ffffff;
+@define-color card_fg_color rgba(0, 0, 0, 0.8);
+@define-color popover_bg_color #ffffff;
+@define-color popover_fg_color rgba(0, 0, 0, 0.8);
+.sidebar {
+  background-color: @window_bg_color;
+}
+
+popover.menu check,
+popover.menu radio {
+  transition: none;
+}
+
+levelbar > trough > block.high, levelbar > trough > block:not(.empty) {
+  background-color: @success_color;
+}
+
+
+button.suggested-action {
+  color: @success_fg_color;
+}
+
+
+button.suggested-action:not(.flat),
+button.suggested-action:checked:not(.flat) {
+  background-color: @success_bg_color;
+}
+
+
+button.flat.suggested-action {
+  color: @success_color;
+}
+
+splitbutton.suggested-action > button, splitbutton.suggested-action > menubutton > button {
+  color: @success_fg_color;
+}
+
+splitbutton.suggested-action > button, splitbutton.suggested-action > button:checked, splitbutton.suggested-action > menubutton > button, splitbutton.suggested-action > menubutton > button:checked {
+  background-color: @success_bg_color;
+}
+
+
+button,
+link {
+  font-weight: normal;
+}

--- a/themes/yaru-bark/gtk.scss
+++ b/themes/yaru-bark/gtk.scss
@@ -1,0 +1,14 @@
+// General guidelines:
+// - very unlikely you want to edit something else than _common.scss
+// - keep the number of defined colors to a minimum, use the color blending functions if
+//   you need a subtle shade
+// - if you need to inverse a color function use the @if directive to match for dark $variant
+
+$variant: 'light';
+
+@import 'palette';
+@import 'defaults';
+@import 'functions';
+@import 'colors';
+@import 'tweaks';
+

--- a/themes/yaru-bark/parse-sass.sh
+++ b/themes/yaru-bark/parse-sass.sh
@@ -1,0 +1,12 @@
+#! /bin/bash
+
+if [ ! "$(which sassc 2> /dev/null)" ]; then
+   echo sassc needs to be installed to generate the css.
+   exit 1
+fi
+
+SASSC_OPT="-M -t expanded"
+
+echo Generating the css...
+
+sassc $SASSC_OPT gtk.scss gtk.css

--- a/themes/yaru-blue-dark/_colors.scss
+++ b/themes/yaru-blue-dark/_colors.scss
@@ -1,0 +1,35 @@
+$accent_bg_color: gtkcolor(accent_bg_color);
+$accent_fg_color: gtkcolor(accent_fg_color);
+$accent_color: gtkcolor(accent_color);
+
+$destructive_bg_color: gtkcolor(destructive_bg_color);
+$destructive_fg_color: gtkcolor(destructive_fg_color);
+$destructive_color: gtkcolor(destructive_color);
+
+$success_bg_color: gtkcolor(success_bg_color);
+$success_fg_color: gtkcolor(success_fg_color);
+$success_color: gtkcolor(success_color);
+
+$warning_bg_color: gtkcolor(warning_bg_color);
+$warning_fg_color: gtkcolor(warning_fg_color);
+$warning_color: gtkcolor(warning_color);
+
+$error_bg_color: gtkcolor(error_bg_color);
+$error_fg_color: gtkcolor(error_fg_color);
+$error_color: gtkcolor(error_color);
+
+$window_bg_color: gtkcolor(window_bg_color);
+$window_fg_color: gtkcolor(window_fg_color);
+
+$view_bg_color: gtkcolor(view_bg_color);
+$view_fg_color: gtkcolor(view_fg_color);
+
+$headerbar_bg_color: gtkcolor(headerbar_bg_color);
+$headerbar_fg_color: gtkcolor(headerbar_fg_color);
+$headerbar_backdrop_color: gtkcolor(headerbar_backdrop_color);
+
+$card_bg_color: gtkcolor(card_bg_color);
+$card_fg_color: gtkcolor(card_fg_color);
+
+$popover_bg_color: gtkcolor(popover_bg_color);
+$popover_fg_color: gtkcolor(popover_fg_color);

--- a/themes/yaru-blue-dark/_defaults.scss
+++ b/themes/yaru-blue-dark/_defaults.scss
@@ -1,0 +1,53 @@
+/* GTK NAMED COLORS
+   ----------------
+   use responsibly! */
+
+// Sass thinks we're using the colors in the variables as strings and may shoot
+// warning, it's innocuous and can be defeated by using #{$var}.
+
+// These are the colors apps are can override. We define the defaults here and
+// define variables for them in _colors.scss
+
+// The main accent color and the matching text value
+@define-color accent_bg_color @yaru_accent_bg_color;
+@define-color accent_fg_color @light_1;
+@define-color accent_color @yaru_accent_bg_color;
+
+// destructive-action buttons
+@define-color destructive_bg_color @red_4;
+@define-color destructive_fg_color @light_1;
+@define-color destructive_color @red_4;
+
+// Levelbars, entries, labels and infobars. These don't need text colors
+@define-color success_bg_color @green_4;
+@define-color success_fg_color @light_1;
+@define-color success_color @green_4;
+
+@define-color warning_bg_color @yellow_5;
+@define-color warning_fg_color @light_1;
+@define-color warning_color @yellow_5;
+
+@define-color error_bg_color @red_4;
+@define-color error_fg_color @light_1;
+@define-color error_color @red_4;
+
+// Window
+@define-color window_bg_color #{if($variant == 'light', #fafafa, lighten(#181818, 8%))};
+@define-color window_fg_color #{if($variant=='light', '@dark_3', '@light_2')};
+
+// Views - e.g. text view or tree view
+@define-color view_bg_color #{if($variant == 'light', #ffffff, #1e1e1e)};
+@define-color view_fg_color #{if($variant == 'light', #000000, #ffffff)};
+
+// Header bar, search bar, tab bar
+@define-color headerbar_bg_color #{if($variant == 'light', #ebebeb, #303030)};
+@define-color headerbar_fg_color #{if($variant == 'light', transparentize(black, .2), white)};
+@define-color headerbar_backdrop_color @window_bg_color;
+
+// Cards, boxed lists
+@define-color card_bg_color #{if($variant == 'light', #ffffff, transparentize(white, .92))};
+@define-color card_fg_color #{if($variant == 'light', transparentize(black, .2), white)};
+
+// Popovers
+@define-color popover_bg_color #{if($variant == 'light', #ffffff, #383838)};
+@define-color popover_fg_color #{if($variant == 'light', transparentize(black, .2), white)};

--- a/themes/yaru-blue-dark/_functions.scss
+++ b/themes/yaru-blue-dark/_functions.scss
@@ -1,0 +1,16 @@
+@function gtkalpha($c,$a) {
+  @return unquote("alpha(#{$c},#{$a})");
+}
+
+@function gtkmix($c1,$c2,$r) {
+  $ratio: 1 -  $r / 100%; // match SCSS mix()
+  @return unquote("mix(#{$c1},#{$c2},#{$ratio})");
+}
+
+@function gtkshade($c,$s) {
+  @return unquote("shade(#{$c},#{$s})");
+}
+
+@function gtkcolor($c) {
+  @return unquote("@#{$c}");
+}

--- a/themes/yaru-blue-dark/_palette.scss
+++ b/themes/yaru-blue-dark/_palette.scss
@@ -1,0 +1,110 @@
+$blue_1: #75d3f4;
+$blue_2: #47c4f1;
+$blue_3: #19B6EE; // Yaru blue
+$blue_4: #007aa6; // Yaru linkblue
+$blue_5: #335280; // Yaru darkblue
+$green_1: #5AED70;
+$green_2: #47D35C;
+$green_3: #34B948;
+$green_4: #219E34;
+$green_5: #0e8420; // Yaru green
+$yellow_1: #FCCD87;
+$yellow_2: #FBC16A;
+$yellow_3: #FBB44C;
+$yellow_4: #FAA82F;
+$yellow_5: #F99B11; // Yaru yellow
+$orange_1: #F29879;
+$orange_2: #F08763;
+$orange_3: #ED764D;
+$orange_4: #EB6536;
+$orange_5: #E95420; // Yaru orange
+$red_1: #EA485C;
+$red_2: #DE374C;
+$red_3: #D3273B;
+$red_4: #c7162b; // Yaru red
+$red_5: #a91224;
+$purple_1: #924D8B; // Yaru aubergine
+$purple_2: #762572; // Yaru purple
+$purple_3: #77216F; // Yaru light aubergine
+$purple_4: #5E2750; // Yaru mid aubergine
+$purple_5: #2C001E; // Yaru dark aubergine
+$brown_1: #E1B289;
+$brown_2: #C5976E;
+$brown_3: #AA7B53;
+$brown_4: #8E6038;
+$brown_5: #72441D;
+$light_1: #FFFFFF;
+$light_2: #F7F7F7; // Yaru porcelain
+$light_3: #CCC; // Yaru silk
+$light_4: #AEA79F; // Yaru warm gray
+$light_5: #878787; // Yaru ash
+$dark_1: #666666; // Yaru graphite
+$dark_2: #5D5D5D; // Yaru slate
+$dark_3: #3D3D3D; // Yaru inkstone
+$dark_4: #181818; // Yaru jet
+$dark_5: #000000;
+
+// Ubuntu accent colors
+$default: $orange_5;
+$bark: #787859;
+$sage: #657B69;
+$olive: #4B8501;
+$viridian: #03875B;
+$prussiangreen: #308280;
+$blue: #0073E5;
+$purple: #7764D8;
+$magenta: #B34CB3;
+$red: #DA3450;
+
+$yaru_accent_bg_color: $blue !default;
+@define-color yaru_accent_bg_color #{$yaru_accent_bg_color};
+
+
+// Sass thinks we're using the colors in the variables as strings and may shoot
+// warning, it's innocuous and can be defeated by using #{$var}.
+
+@define-color blue_1 #{$blue_1};
+@define-color blue_2 #{$blue_2};
+@define-color blue_3 #{$blue_3};
+@define-color blue_4 #{$blue_4};
+@define-color blue_5 #{$blue_5};
+@define-color green_1 #{$green_1};
+@define-color green_2 #{$green_2};
+@define-color green_3 #{$green_3};
+@define-color green_4 #{$green_4};
+@define-color green_5 #{$green_5};
+@define-color yellow_1 #{$yellow_1};
+@define-color yellow_2 #{$yellow_2};
+@define-color yellow_3 #{$yellow_3};
+@define-color yellow_4 #{$yellow_4};
+@define-color yellow_5 #{$yellow_5};
+@define-color orange_1 #{$orange_1};
+@define-color orange_2 #{$orange_2};
+@define-color orange_3 #{$orange_3};
+@define-color orange_4 #{$orange_4};
+@define-color orange_5 #{$orange_5};
+@define-color red_1 #{$red_1};
+@define-color red_2 #{$red_2};
+@define-color red_3 #{$red_3};
+@define-color red_4 #{$red_4};
+@define-color red_5 #{$red_5};
+@define-color purple_1 #{$purple_1};
+@define-color purple_2 #{$purple_2};
+@define-color purple_3 #{$purple_3};
+@define-color purple_4 #{$purple_4};
+@define-color purple_5 #{$purple_5};
+@define-color brown_1 #{$brown_1};
+@define-color brown_2 #{$brown_2};
+@define-color brown_3 #{$brown_3};
+@define-color brown_4 #{$brown_4};
+@define-color brown_5 #{$brown_5};
+@define-color light_1 #{$light_1};
+@define-color light_2 #{$light_2};
+@define-color light_3 #{$light_3};
+@define-color light_4 #{$light_4};
+@define-color light_5 #{$light_5};
+@define-color dark_1 #{$dark_1};
+@define-color dark_2 #{$dark_2};
+@define-color dark_3 #{$dark_3};
+@define-color dark_4 #{$dark_4};
+@define-color dark_5 #{$dark_5};

--- a/themes/yaru-blue-dark/_tweaks.scss
+++ b/themes/yaru-blue-dark/_tweaks.scss
@@ -1,0 +1,73 @@
+// Reducing the amount of the palette's background colors to two
+.sidebar {
+	background-color: $window_bg_color;
+}
+
+// Entries drown if drawn on widgets with $base_color
+// Fixing this at least for notebooks, since entries on tabs is a common pattern
+// Remove this when upstream makes entries have a light border in the dark theme
+@if $variant== "dark" {
+	notebook entry {
+			background-color: gtkmix($view_bg_color, black, 98%);
+	}
+}
+
+// Fix popover wiggling effect (see #2903)
+popover.menu {
+	check,
+	radio {
+			transition: none;
+	}
+}
+
+// Use our own palette for high and not empty levelbar
+levelbar {
+	> trough {
+			> block {
+					&.high,
+					&:not(.empty) {
+							background-color: $success_color;
+					}
+			}
+	}
+}
+
+// Green suggested buttons
+%button,
+button {
+	&.suggested-action {
+			color: $success_fg_color;
+
+			&,
+			&:checked {
+					&:not(.flat) {
+							background-color: $success_bg_color;
+					}
+			}
+	}
+
+	&.flat {
+			&.suggested-action {
+					color: $success_color;
+			}
+	}
+}
+
+splitbutton {
+	&.suggested-action {
+			> button, > menubutton > button {
+					color: $success_fg_color;
+	
+					&, &:checked {
+							background-color: $success_bg_color;
+					}
+			}
+	}
+}
+
+%button,
+button,
+%link,
+link {
+	font-weight: normal;
+}

--- a/themes/yaru-blue-dark/gtk-dark.scss
+++ b/themes/yaru-blue-dark/gtk-dark.scss
@@ -1,0 +1,13 @@
+// General guidelines:
+// - very unlikely you want to edit something else than _common.scss
+// - keep the number of defined colors to a minimum, use the color blending functions if
+//   you need a subtle shade
+// - if you need to inverse a color function use the @if directive to match for dark $variant
+
+$variant: 'dark';
+
+@import 'palette';
+@import 'defaults';
+@import 'functions';
+@import 'colors';
+@import 'tweaks';

--- a/themes/yaru-blue-dark/gtk.css
+++ b/themes/yaru-blue-dark/gtk.css
@@ -1,0 +1,121 @@
+@define-color yaru_accent_bg_color #0073E5;
+@define-color blue_1 #75d3f4;
+@define-color blue_2 #47c4f1;
+@define-color blue_3 #19B6EE;
+@define-color blue_4 #007aa6;
+@define-color blue_5 #335280;
+@define-color green_1 #5AED70;
+@define-color green_2 #47D35C;
+@define-color green_3 #34B948;
+@define-color green_4 #219E34;
+@define-color green_5 #0e8420;
+@define-color yellow_1 #FCCD87;
+@define-color yellow_2 #FBC16A;
+@define-color yellow_3 #FBB44C;
+@define-color yellow_4 #FAA82F;
+@define-color yellow_5 #F99B11;
+@define-color orange_1 #F29879;
+@define-color orange_2 #F08763;
+@define-color orange_3 #ED764D;
+@define-color orange_4 #EB6536;
+@define-color orange_5 #E95420;
+@define-color red_1 #EA485C;
+@define-color red_2 #DE374C;
+@define-color red_3 #D3273B;
+@define-color red_4 #c7162b;
+@define-color red_5 #a91224;
+@define-color purple_1 #924D8B;
+@define-color purple_2 #762572;
+@define-color purple_3 #77216F;
+@define-color purple_4 #5E2750;
+@define-color purple_5 #2C001E;
+@define-color brown_1 #E1B289;
+@define-color brown_2 #C5976E;
+@define-color brown_3 #AA7B53;
+@define-color brown_4 #8E6038;
+@define-color brown_5 #72441D;
+@define-color light_1 #FFFFFF;
+@define-color light_2 #F7F7F7;
+@define-color light_3 #CCC;
+@define-color light_4 #AEA79F;
+@define-color light_5 #878787;
+@define-color dark_1 #666666;
+@define-color dark_2 #5D5D5D;
+@define-color dark_3 #3D3D3D;
+@define-color dark_4 #181818;
+@define-color dark_5 #000000;
+/* GTK NAMED COLORS
+   ----------------
+   use responsibly! */
+@define-color accent_bg_color @yaru_accent_bg_color;
+@define-color accent_fg_color @light_1;
+@define-color accent_color @yaru_accent_bg_color;
+@define-color destructive_bg_color @red_4;
+@define-color destructive_fg_color @light_1;
+@define-color destructive_color @red_4;
+@define-color success_bg_color @green_4;
+@define-color success_fg_color @light_1;
+@define-color success_color @green_4;
+@define-color warning_bg_color @yellow_5;
+@define-color warning_fg_color @light_1;
+@define-color warning_color @yellow_5;
+@define-color error_bg_color @red_4;
+@define-color error_fg_color @light_1;
+@define-color error_color @red_4;
+@define-color window_bg_color #2c2c2c;
+@define-color window_fg_color @light_2;
+@define-color view_bg_color #1e1e1e;
+@define-color view_fg_color #ffffff;
+@define-color headerbar_bg_color #303030;
+@define-color headerbar_fg_color white;
+@define-color headerbar_backdrop_color @window_bg_color;
+@define-color card_bg_color rgba(255, 255, 255, 0.08);
+@define-color card_fg_color white;
+@define-color popover_bg_color #383838;
+@define-color popover_fg_color white;
+.sidebar {
+  background-color: @window_bg_color;
+}
+
+notebook entry {
+  background-color: mix(@view_bg_color,black,0.02);
+}
+
+popover.menu check,
+popover.menu radio {
+  transition: none;
+}
+
+levelbar > trough > block.high, levelbar > trough > block:not(.empty) {
+  background-color: @success_color;
+}
+
+
+button.suggested-action {
+  color: @success_fg_color;
+}
+
+
+button.suggested-action:not(.flat),
+button.suggested-action:checked:not(.flat) {
+  background-color: @success_bg_color;
+}
+
+
+button.flat.suggested-action {
+  color: @success_color;
+}
+
+splitbutton.suggested-action > button, splitbutton.suggested-action > menubutton > button {
+  color: @success_fg_color;
+}
+
+splitbutton.suggested-action > button, splitbutton.suggested-action > button:checked, splitbutton.suggested-action > menubutton > button, splitbutton.suggested-action > menubutton > button:checked {
+  background-color: @success_bg_color;
+}
+
+
+button,
+link {
+  font-weight: normal;
+}

--- a/themes/yaru-blue-dark/gtk.scss
+++ b/themes/yaru-blue-dark/gtk.scss
@@ -1,0 +1,14 @@
+// General guidelines:
+// - very unlikely you want to edit something else than _common.scss
+// - keep the number of defined colors to a minimum, use the color blending functions if
+//   you need a subtle shade
+// - if you need to inverse a color function use the @if directive to match for dark $variant
+
+$variant: 'light';
+
+@import 'palette';
+@import 'defaults';
+@import 'functions';
+@import 'colors';
+@import 'tweaks';
+

--- a/themes/yaru-blue-dark/parse-sass.sh
+++ b/themes/yaru-blue-dark/parse-sass.sh
@@ -1,0 +1,12 @@
+#! /bin/bash
+
+if [ ! "$(which sassc 2> /dev/null)" ]; then
+   echo sassc needs to be installed to generate the css.
+   exit 1
+fi
+
+SASSC_OPT="-M -t expanded"
+
+echo Generating the css...
+
+sassc $SASSC_OPT gtk-dark.scss gtk.css

--- a/themes/yaru-blue/_colors.scss
+++ b/themes/yaru-blue/_colors.scss
@@ -1,0 +1,35 @@
+$accent_bg_color: gtkcolor(accent_bg_color);
+$accent_fg_color: gtkcolor(accent_fg_color);
+$accent_color: gtkcolor(accent_color);
+
+$destructive_bg_color: gtkcolor(destructive_bg_color);
+$destructive_fg_color: gtkcolor(destructive_fg_color);
+$destructive_color: gtkcolor(destructive_color);
+
+$success_bg_color: gtkcolor(success_bg_color);
+$success_fg_color: gtkcolor(success_fg_color);
+$success_color: gtkcolor(success_color);
+
+$warning_bg_color: gtkcolor(warning_bg_color);
+$warning_fg_color: gtkcolor(warning_fg_color);
+$warning_color: gtkcolor(warning_color);
+
+$error_bg_color: gtkcolor(error_bg_color);
+$error_fg_color: gtkcolor(error_fg_color);
+$error_color: gtkcolor(error_color);
+
+$window_bg_color: gtkcolor(window_bg_color);
+$window_fg_color: gtkcolor(window_fg_color);
+
+$view_bg_color: gtkcolor(view_bg_color);
+$view_fg_color: gtkcolor(view_fg_color);
+
+$headerbar_bg_color: gtkcolor(headerbar_bg_color);
+$headerbar_fg_color: gtkcolor(headerbar_fg_color);
+$headerbar_backdrop_color: gtkcolor(headerbar_backdrop_color);
+
+$card_bg_color: gtkcolor(card_bg_color);
+$card_fg_color: gtkcolor(card_fg_color);
+
+$popover_bg_color: gtkcolor(popover_bg_color);
+$popover_fg_color: gtkcolor(popover_fg_color);

--- a/themes/yaru-blue/_defaults.scss
+++ b/themes/yaru-blue/_defaults.scss
@@ -1,0 +1,53 @@
+/* GTK NAMED COLORS
+   ----------------
+   use responsibly! */
+
+// Sass thinks we're using the colors in the variables as strings and may shoot
+// warning, it's innocuous and can be defeated by using #{$var}.
+
+// These are the colors apps are can override. We define the defaults here and
+// define variables for them in _colors.scss
+
+// The main accent color and the matching text value
+@define-color accent_bg_color @yaru_accent_bg_color;
+@define-color accent_fg_color @light_1;
+@define-color accent_color @yaru_accent_bg_color;
+
+// destructive-action buttons
+@define-color destructive_bg_color @red_4;
+@define-color destructive_fg_color @light_1;
+@define-color destructive_color @red_4;
+
+// Levelbars, entries, labels and infobars. These don't need text colors
+@define-color success_bg_color @green_4;
+@define-color success_fg_color @light_1;
+@define-color success_color @green_4;
+
+@define-color warning_bg_color @yellow_5;
+@define-color warning_fg_color @light_1;
+@define-color warning_color @yellow_5;
+
+@define-color error_bg_color @red_4;
+@define-color error_fg_color @light_1;
+@define-color error_color @red_4;
+
+// Window
+@define-color window_bg_color #{if($variant == 'light', #fafafa, lighten(#181818, 8%))};
+@define-color window_fg_color #{if($variant=='light', '@dark_3', '@light_2')};
+
+// Views - e.g. text view or tree view
+@define-color view_bg_color #{if($variant == 'light', #ffffff, #1e1e1e)};
+@define-color view_fg_color #{if($variant == 'light', #000000, #ffffff)};
+
+// Header bar, search bar, tab bar
+@define-color headerbar_bg_color #{if($variant == 'light', #ebebeb, #303030)};
+@define-color headerbar_fg_color #{if($variant == 'light', transparentize(black, .2), white)};
+@define-color headerbar_backdrop_color @window_bg_color;
+
+// Cards, boxed lists
+@define-color card_bg_color #{if($variant == 'light', #ffffff, transparentize(white, .92))};
+@define-color card_fg_color #{if($variant == 'light', transparentize(black, .2), white)};
+
+// Popovers
+@define-color popover_bg_color #{if($variant == 'light', #ffffff, #383838)};
+@define-color popover_fg_color #{if($variant == 'light', transparentize(black, .2), white)};

--- a/themes/yaru-blue/_functions.scss
+++ b/themes/yaru-blue/_functions.scss
@@ -1,0 +1,16 @@
+@function gtkalpha($c,$a) {
+  @return unquote("alpha(#{$c},#{$a})");
+}
+
+@function gtkmix($c1,$c2,$r) {
+  $ratio: 1 -  $r / 100%; // match SCSS mix()
+  @return unquote("mix(#{$c1},#{$c2},#{$ratio})");
+}
+
+@function gtkshade($c,$s) {
+  @return unquote("shade(#{$c},#{$s})");
+}
+
+@function gtkcolor($c) {
+  @return unquote("@#{$c}");
+}

--- a/themes/yaru-blue/_palette.scss
+++ b/themes/yaru-blue/_palette.scss
@@ -1,0 +1,110 @@
+$blue_1: #75d3f4;
+$blue_2: #47c4f1;
+$blue_3: #19B6EE; // Yaru blue
+$blue_4: #007aa6; // Yaru linkblue
+$blue_5: #335280; // Yaru darkblue
+$green_1: #5AED70;
+$green_2: #47D35C;
+$green_3: #34B948;
+$green_4: #219E34;
+$green_5: #0e8420; // Yaru green
+$yellow_1: #FCCD87;
+$yellow_2: #FBC16A;
+$yellow_3: #FBB44C;
+$yellow_4: #FAA82F;
+$yellow_5: #F99B11; // Yaru yellow
+$orange_1: #F29879;
+$orange_2: #F08763;
+$orange_3: #ED764D;
+$orange_4: #EB6536;
+$orange_5: #E95420; // Yaru orange
+$red_1: #EA485C;
+$red_2: #DE374C;
+$red_3: #D3273B;
+$red_4: #c7162b; // Yaru red
+$red_5: #a91224;
+$purple_1: #924D8B; // Yaru aubergine
+$purple_2: #762572; // Yaru purple
+$purple_3: #77216F; // Yaru light aubergine
+$purple_4: #5E2750; // Yaru mid aubergine
+$purple_5: #2C001E; // Yaru dark aubergine
+$brown_1: #E1B289;
+$brown_2: #C5976E;
+$brown_3: #AA7B53;
+$brown_4: #8E6038;
+$brown_5: #72441D;
+$light_1: #FFFFFF;
+$light_2: #F7F7F7; // Yaru porcelain
+$light_3: #CCC; // Yaru silk
+$light_4: #AEA79F; // Yaru warm gray
+$light_5: #878787; // Yaru ash
+$dark_1: #666666; // Yaru graphite
+$dark_2: #5D5D5D; // Yaru slate
+$dark_3: #3D3D3D; // Yaru inkstone
+$dark_4: #181818; // Yaru jet
+$dark_5: #000000;
+
+// Ubuntu accent colors
+$default: $orange_5;
+$bark: #787859;
+$sage: #657B69;
+$olive: #4B8501;
+$viridian: #03875B;
+$prussiangreen: #308280;
+$blue: #0073E5;
+$purple: #7764D8;
+$magenta: #B34CB3;
+$red: #DA3450;
+
+$yaru_accent_bg_color: $blue !default;
+@define-color yaru_accent_bg_color #{$yaru_accent_bg_color};
+
+
+// Sass thinks we're using the colors in the variables as strings and may shoot
+// warning, it's innocuous and can be defeated by using #{$var}.
+
+@define-color blue_1 #{$blue_1};
+@define-color blue_2 #{$blue_2};
+@define-color blue_3 #{$blue_3};
+@define-color blue_4 #{$blue_4};
+@define-color blue_5 #{$blue_5};
+@define-color green_1 #{$green_1};
+@define-color green_2 #{$green_2};
+@define-color green_3 #{$green_3};
+@define-color green_4 #{$green_4};
+@define-color green_5 #{$green_5};
+@define-color yellow_1 #{$yellow_1};
+@define-color yellow_2 #{$yellow_2};
+@define-color yellow_3 #{$yellow_3};
+@define-color yellow_4 #{$yellow_4};
+@define-color yellow_5 #{$yellow_5};
+@define-color orange_1 #{$orange_1};
+@define-color orange_2 #{$orange_2};
+@define-color orange_3 #{$orange_3};
+@define-color orange_4 #{$orange_4};
+@define-color orange_5 #{$orange_5};
+@define-color red_1 #{$red_1};
+@define-color red_2 #{$red_2};
+@define-color red_3 #{$red_3};
+@define-color red_4 #{$red_4};
+@define-color red_5 #{$red_5};
+@define-color purple_1 #{$purple_1};
+@define-color purple_2 #{$purple_2};
+@define-color purple_3 #{$purple_3};
+@define-color purple_4 #{$purple_4};
+@define-color purple_5 #{$purple_5};
+@define-color brown_1 #{$brown_1};
+@define-color brown_2 #{$brown_2};
+@define-color brown_3 #{$brown_3};
+@define-color brown_4 #{$brown_4};
+@define-color brown_5 #{$brown_5};
+@define-color light_1 #{$light_1};
+@define-color light_2 #{$light_2};
+@define-color light_3 #{$light_3};
+@define-color light_4 #{$light_4};
+@define-color light_5 #{$light_5};
+@define-color dark_1 #{$dark_1};
+@define-color dark_2 #{$dark_2};
+@define-color dark_3 #{$dark_3};
+@define-color dark_4 #{$dark_4};
+@define-color dark_5 #{$dark_5};

--- a/themes/yaru-blue/_tweaks.scss
+++ b/themes/yaru-blue/_tweaks.scss
@@ -1,0 +1,73 @@
+// Reducing the amount of the palette's background colors to two
+.sidebar {
+	background-color: $window_bg_color;
+}
+
+// Entries drown if drawn on widgets with $base_color
+// Fixing this at least for notebooks, since entries on tabs is a common pattern
+// Remove this when upstream makes entries have a light border in the dark theme
+@if $variant== "dark" {
+	notebook entry {
+			background-color: gtkmix($view_bg_color, black, 98%);
+	}
+}
+
+// Fix popover wiggling effect (see #2903)
+popover.menu {
+	check,
+	radio {
+			transition: none;
+	}
+}
+
+// Use our own palette for high and not empty levelbar
+levelbar {
+	> trough {
+			> block {
+					&.high,
+					&:not(.empty) {
+							background-color: $success_color;
+					}
+			}
+	}
+}
+
+// Green suggested buttons
+%button,
+button {
+	&.suggested-action {
+			color: $success_fg_color;
+
+			&,
+			&:checked {
+					&:not(.flat) {
+							background-color: $success_bg_color;
+					}
+			}
+	}
+
+	&.flat {
+			&.suggested-action {
+					color: $success_color;
+			}
+	}
+}
+
+splitbutton {
+	&.suggested-action {
+			> button, > menubutton > button {
+					color: $success_fg_color;
+	
+					&, &:checked {
+							background-color: $success_bg_color;
+					}
+			}
+	}
+}
+
+%button,
+button,
+%link,
+link {
+	font-weight: normal;
+}

--- a/themes/yaru-blue/gtk-dark.scss
+++ b/themes/yaru-blue/gtk-dark.scss
@@ -1,0 +1,13 @@
+// General guidelines:
+// - very unlikely you want to edit something else than _common.scss
+// - keep the number of defined colors to a minimum, use the color blending functions if
+//   you need a subtle shade
+// - if you need to inverse a color function use the @if directive to match for dark $variant
+
+$variant: 'dark';
+
+@import 'palette';
+@import 'defaults';
+@import 'functions';
+@import 'colors';
+@import 'tweaks';

--- a/themes/yaru-blue/gtk.css
+++ b/themes/yaru-blue/gtk.css
@@ -1,0 +1,117 @@
+@define-color yaru_accent_bg_color #0073E5;
+@define-color blue_1 #75d3f4;
+@define-color blue_2 #47c4f1;
+@define-color blue_3 #19B6EE;
+@define-color blue_4 #007aa6;
+@define-color blue_5 #335280;
+@define-color green_1 #5AED70;
+@define-color green_2 #47D35C;
+@define-color green_3 #34B948;
+@define-color green_4 #219E34;
+@define-color green_5 #0e8420;
+@define-color yellow_1 #FCCD87;
+@define-color yellow_2 #FBC16A;
+@define-color yellow_3 #FBB44C;
+@define-color yellow_4 #FAA82F;
+@define-color yellow_5 #F99B11;
+@define-color orange_1 #F29879;
+@define-color orange_2 #F08763;
+@define-color orange_3 #ED764D;
+@define-color orange_4 #EB6536;
+@define-color orange_5 #E95420;
+@define-color red_1 #EA485C;
+@define-color red_2 #DE374C;
+@define-color red_3 #D3273B;
+@define-color red_4 #c7162b;
+@define-color red_5 #a91224;
+@define-color purple_1 #924D8B;
+@define-color purple_2 #762572;
+@define-color purple_3 #77216F;
+@define-color purple_4 #5E2750;
+@define-color purple_5 #2C001E;
+@define-color brown_1 #E1B289;
+@define-color brown_2 #C5976E;
+@define-color brown_3 #AA7B53;
+@define-color brown_4 #8E6038;
+@define-color brown_5 #72441D;
+@define-color light_1 #FFFFFF;
+@define-color light_2 #F7F7F7;
+@define-color light_3 #CCC;
+@define-color light_4 #AEA79F;
+@define-color light_5 #878787;
+@define-color dark_1 #666666;
+@define-color dark_2 #5D5D5D;
+@define-color dark_3 #3D3D3D;
+@define-color dark_4 #181818;
+@define-color dark_5 #000000;
+/* GTK NAMED COLORS
+   ----------------
+   use responsibly! */
+@define-color accent_bg_color @yaru_accent_bg_color;
+@define-color accent_fg_color @light_1;
+@define-color accent_color @yaru_accent_bg_color;
+@define-color destructive_bg_color @red_4;
+@define-color destructive_fg_color @light_1;
+@define-color destructive_color @red_4;
+@define-color success_bg_color @green_4;
+@define-color success_fg_color @light_1;
+@define-color success_color @green_4;
+@define-color warning_bg_color @yellow_5;
+@define-color warning_fg_color @light_1;
+@define-color warning_color @yellow_5;
+@define-color error_bg_color @red_4;
+@define-color error_fg_color @light_1;
+@define-color error_color @red_4;
+@define-color window_bg_color #fafafa;
+@define-color window_fg_color @dark_3;
+@define-color view_bg_color #ffffff;
+@define-color view_fg_color #000000;
+@define-color headerbar_bg_color #ebebeb;
+@define-color headerbar_fg_color rgba(0, 0, 0, 0.8);
+@define-color headerbar_backdrop_color @window_bg_color;
+@define-color card_bg_color #ffffff;
+@define-color card_fg_color rgba(0, 0, 0, 0.8);
+@define-color popover_bg_color #ffffff;
+@define-color popover_fg_color rgba(0, 0, 0, 0.8);
+.sidebar {
+  background-color: @window_bg_color;
+}
+
+popover.menu check,
+popover.menu radio {
+  transition: none;
+}
+
+levelbar > trough > block.high, levelbar > trough > block:not(.empty) {
+  background-color: @success_color;
+}
+
+
+button.suggested-action {
+  color: @success_fg_color;
+}
+
+
+button.suggested-action:not(.flat),
+button.suggested-action:checked:not(.flat) {
+  background-color: @success_bg_color;
+}
+
+
+button.flat.suggested-action {
+  color: @success_color;
+}
+
+splitbutton.suggested-action > button, splitbutton.suggested-action > menubutton > button {
+  color: @success_fg_color;
+}
+
+splitbutton.suggested-action > button, splitbutton.suggested-action > button:checked, splitbutton.suggested-action > menubutton > button, splitbutton.suggested-action > menubutton > button:checked {
+  background-color: @success_bg_color;
+}
+
+
+button,
+link {
+  font-weight: normal;
+}

--- a/themes/yaru-blue/gtk.scss
+++ b/themes/yaru-blue/gtk.scss
@@ -1,0 +1,14 @@
+// General guidelines:
+// - very unlikely you want to edit something else than _common.scss
+// - keep the number of defined colors to a minimum, use the color blending functions if
+//   you need a subtle shade
+// - if you need to inverse a color function use the @if directive to match for dark $variant
+
+$variant: 'light';
+
+@import 'palette';
+@import 'defaults';
+@import 'functions';
+@import 'colors';
+@import 'tweaks';
+

--- a/themes/yaru-blue/parse-sass.sh
+++ b/themes/yaru-blue/parse-sass.sh
@@ -1,0 +1,12 @@
+#! /bin/bash
+
+if [ ! "$(which sassc 2> /dev/null)" ]; then
+   echo sassc needs to be installed to generate the css.
+   exit 1
+fi
+
+SASSC_OPT="-M -t expanded"
+
+echo Generating the css...
+
+sassc $SASSC_OPT gtk.scss gtk.css

--- a/themes/yaru-magenta-dark/_colors.scss
+++ b/themes/yaru-magenta-dark/_colors.scss
@@ -1,0 +1,35 @@
+$accent_bg_color: gtkcolor(accent_bg_color);
+$accent_fg_color: gtkcolor(accent_fg_color);
+$accent_color: gtkcolor(accent_color);
+
+$destructive_bg_color: gtkcolor(destructive_bg_color);
+$destructive_fg_color: gtkcolor(destructive_fg_color);
+$destructive_color: gtkcolor(destructive_color);
+
+$success_bg_color: gtkcolor(success_bg_color);
+$success_fg_color: gtkcolor(success_fg_color);
+$success_color: gtkcolor(success_color);
+
+$warning_bg_color: gtkcolor(warning_bg_color);
+$warning_fg_color: gtkcolor(warning_fg_color);
+$warning_color: gtkcolor(warning_color);
+
+$error_bg_color: gtkcolor(error_bg_color);
+$error_fg_color: gtkcolor(error_fg_color);
+$error_color: gtkcolor(error_color);
+
+$window_bg_color: gtkcolor(window_bg_color);
+$window_fg_color: gtkcolor(window_fg_color);
+
+$view_bg_color: gtkcolor(view_bg_color);
+$view_fg_color: gtkcolor(view_fg_color);
+
+$headerbar_bg_color: gtkcolor(headerbar_bg_color);
+$headerbar_fg_color: gtkcolor(headerbar_fg_color);
+$headerbar_backdrop_color: gtkcolor(headerbar_backdrop_color);
+
+$card_bg_color: gtkcolor(card_bg_color);
+$card_fg_color: gtkcolor(card_fg_color);
+
+$popover_bg_color: gtkcolor(popover_bg_color);
+$popover_fg_color: gtkcolor(popover_fg_color);

--- a/themes/yaru-magenta-dark/_defaults.scss
+++ b/themes/yaru-magenta-dark/_defaults.scss
@@ -1,0 +1,53 @@
+/* GTK NAMED COLORS
+   ----------------
+   use responsibly! */
+
+// Sass thinks we're using the colors in the variables as strings and may shoot
+// warning, it's innocuous and can be defeated by using #{$var}.
+
+// These are the colors apps are can override. We define the defaults here and
+// define variables for them in _colors.scss
+
+// The main accent color and the matching text value
+@define-color accent_bg_color @yaru_accent_bg_color;
+@define-color accent_fg_color @light_1;
+@define-color accent_color @yaru_accent_bg_color;
+
+// destructive-action buttons
+@define-color destructive_bg_color @red_4;
+@define-color destructive_fg_color @light_1;
+@define-color destructive_color @red_4;
+
+// Levelbars, entries, labels and infobars. These don't need text colors
+@define-color success_bg_color @green_4;
+@define-color success_fg_color @light_1;
+@define-color success_color @green_4;
+
+@define-color warning_bg_color @yellow_5;
+@define-color warning_fg_color @light_1;
+@define-color warning_color @yellow_5;
+
+@define-color error_bg_color @red_4;
+@define-color error_fg_color @light_1;
+@define-color error_color @red_4;
+
+// Window
+@define-color window_bg_color #{if($variant == 'light', #fafafa, lighten(#181818, 8%))};
+@define-color window_fg_color #{if($variant=='light', '@dark_3', '@light_2')};
+
+// Views - e.g. text view or tree view
+@define-color view_bg_color #{if($variant == 'light', #ffffff, #1e1e1e)};
+@define-color view_fg_color #{if($variant == 'light', #000000, #ffffff)};
+
+// Header bar, search bar, tab bar
+@define-color headerbar_bg_color #{if($variant == 'light', #ebebeb, #303030)};
+@define-color headerbar_fg_color #{if($variant == 'light', transparentize(black, .2), white)};
+@define-color headerbar_backdrop_color @window_bg_color;
+
+// Cards, boxed lists
+@define-color card_bg_color #{if($variant == 'light', #ffffff, transparentize(white, .92))};
+@define-color card_fg_color #{if($variant == 'light', transparentize(black, .2), white)};
+
+// Popovers
+@define-color popover_bg_color #{if($variant == 'light', #ffffff, #383838)};
+@define-color popover_fg_color #{if($variant == 'light', transparentize(black, .2), white)};

--- a/themes/yaru-magenta-dark/_functions.scss
+++ b/themes/yaru-magenta-dark/_functions.scss
@@ -1,0 +1,16 @@
+@function gtkalpha($c,$a) {
+  @return unquote("alpha(#{$c},#{$a})");
+}
+
+@function gtkmix($c1,$c2,$r) {
+  $ratio: 1 -  $r / 100%; // match SCSS mix()
+  @return unquote("mix(#{$c1},#{$c2},#{$ratio})");
+}
+
+@function gtkshade($c,$s) {
+  @return unquote("shade(#{$c},#{$s})");
+}
+
+@function gtkcolor($c) {
+  @return unquote("@#{$c}");
+}

--- a/themes/yaru-magenta-dark/_palette.scss
+++ b/themes/yaru-magenta-dark/_palette.scss
@@ -1,0 +1,110 @@
+$blue_1: #75d3f4;
+$blue_2: #47c4f1;
+$blue_3: #19B6EE; // Yaru blue
+$blue_4: #007aa6; // Yaru linkblue
+$blue_5: #335280; // Yaru darkblue
+$green_1: #5AED70;
+$green_2: #47D35C;
+$green_3: #34B948;
+$green_4: #219E34;
+$green_5: #0e8420; // Yaru green
+$yellow_1: #FCCD87;
+$yellow_2: #FBC16A;
+$yellow_3: #FBB44C;
+$yellow_4: #FAA82F;
+$yellow_5: #F99B11; // Yaru yellow
+$orange_1: #F29879;
+$orange_2: #F08763;
+$orange_3: #ED764D;
+$orange_4: #EB6536;
+$orange_5: #E95420; // Yaru orange
+$red_1: #EA485C;
+$red_2: #DE374C;
+$red_3: #D3273B;
+$red_4: #c7162b; // Yaru red
+$red_5: #a91224;
+$purple_1: #924D8B; // Yaru aubergine
+$purple_2: #762572; // Yaru purple
+$purple_3: #77216F; // Yaru light aubergine
+$purple_4: #5E2750; // Yaru mid aubergine
+$purple_5: #2C001E; // Yaru dark aubergine
+$brown_1: #E1B289;
+$brown_2: #C5976E;
+$brown_3: #AA7B53;
+$brown_4: #8E6038;
+$brown_5: #72441D;
+$light_1: #FFFFFF;
+$light_2: #F7F7F7; // Yaru porcelain
+$light_3: #CCC; // Yaru silk
+$light_4: #AEA79F; // Yaru warm gray
+$light_5: #878787; // Yaru ash
+$dark_1: #666666; // Yaru graphite
+$dark_2: #5D5D5D; // Yaru slate
+$dark_3: #3D3D3D; // Yaru inkstone
+$dark_4: #181818; // Yaru jet
+$dark_5: #000000;
+
+// Ubuntu accent colors
+$default: $orange_5;
+$bark: #787859;
+$sage: #657B69;
+$olive: #4B8501;
+$viridian: #03875B;
+$prussiangreen: #308280;
+$blue: #0073E5;
+$purple: #7764D8;
+$magenta: #B34CB3;
+$red: #DA3450;
+
+$yaru_accent_bg_color: $magenta !default;
+@define-color yaru_accent_bg_color #{$yaru_accent_bg_color};
+
+
+// Sass thinks we're using the colors in the variables as strings and may shoot
+// warning, it's innocuous and can be defeated by using #{$var}.
+
+@define-color blue_1 #{$blue_1};
+@define-color blue_2 #{$blue_2};
+@define-color blue_3 #{$blue_3};
+@define-color blue_4 #{$blue_4};
+@define-color blue_5 #{$blue_5};
+@define-color green_1 #{$green_1};
+@define-color green_2 #{$green_2};
+@define-color green_3 #{$green_3};
+@define-color green_4 #{$green_4};
+@define-color green_5 #{$green_5};
+@define-color yellow_1 #{$yellow_1};
+@define-color yellow_2 #{$yellow_2};
+@define-color yellow_3 #{$yellow_3};
+@define-color yellow_4 #{$yellow_4};
+@define-color yellow_5 #{$yellow_5};
+@define-color orange_1 #{$orange_1};
+@define-color orange_2 #{$orange_2};
+@define-color orange_3 #{$orange_3};
+@define-color orange_4 #{$orange_4};
+@define-color orange_5 #{$orange_5};
+@define-color red_1 #{$red_1};
+@define-color red_2 #{$red_2};
+@define-color red_3 #{$red_3};
+@define-color red_4 #{$red_4};
+@define-color red_5 #{$red_5};
+@define-color purple_1 #{$purple_1};
+@define-color purple_2 #{$purple_2};
+@define-color purple_3 #{$purple_3};
+@define-color purple_4 #{$purple_4};
+@define-color purple_5 #{$purple_5};
+@define-color brown_1 #{$brown_1};
+@define-color brown_2 #{$brown_2};
+@define-color brown_3 #{$brown_3};
+@define-color brown_4 #{$brown_4};
+@define-color brown_5 #{$brown_5};
+@define-color light_1 #{$light_1};
+@define-color light_2 #{$light_2};
+@define-color light_3 #{$light_3};
+@define-color light_4 #{$light_4};
+@define-color light_5 #{$light_5};
+@define-color dark_1 #{$dark_1};
+@define-color dark_2 #{$dark_2};
+@define-color dark_3 #{$dark_3};
+@define-color dark_4 #{$dark_4};
+@define-color dark_5 #{$dark_5};

--- a/themes/yaru-magenta-dark/_tweaks.scss
+++ b/themes/yaru-magenta-dark/_tweaks.scss
@@ -1,0 +1,73 @@
+// Reducing the amount of the palette's background colors to two
+.sidebar {
+	background-color: $window_bg_color;
+}
+
+// Entries drown if drawn on widgets with $base_color
+// Fixing this at least for notebooks, since entries on tabs is a common pattern
+// Remove this when upstream makes entries have a light border in the dark theme
+@if $variant== "dark" {
+	notebook entry {
+			background-color: gtkmix($view_bg_color, black, 98%);
+	}
+}
+
+// Fix popover wiggling effect (see #2903)
+popover.menu {
+	check,
+	radio {
+			transition: none;
+	}
+}
+
+// Use our own palette for high and not empty levelbar
+levelbar {
+	> trough {
+			> block {
+					&.high,
+					&:not(.empty) {
+							background-color: $success_color;
+					}
+			}
+	}
+}
+
+// Green suggested buttons
+%button,
+button {
+	&.suggested-action {
+			color: $success_fg_color;
+
+			&,
+			&:checked {
+					&:not(.flat) {
+							background-color: $success_bg_color;
+					}
+			}
+	}
+
+	&.flat {
+			&.suggested-action {
+					color: $success_color;
+			}
+	}
+}
+
+splitbutton {
+	&.suggested-action {
+			> button, > menubutton > button {
+					color: $success_fg_color;
+	
+					&, &:checked {
+							background-color: $success_bg_color;
+					}
+			}
+	}
+}
+
+%button,
+button,
+%link,
+link {
+	font-weight: normal;
+}

--- a/themes/yaru-magenta-dark/gtk-dark.scss
+++ b/themes/yaru-magenta-dark/gtk-dark.scss
@@ -1,0 +1,13 @@
+// General guidelines:
+// - very unlikely you want to edit something else than _common.scss
+// - keep the number of defined colors to a minimum, use the color blending functions if
+//   you need a subtle shade
+// - if you need to inverse a color function use the @if directive to match for dark $variant
+
+$variant: 'dark';
+
+@import 'palette';
+@import 'defaults';
+@import 'functions';
+@import 'colors';
+@import 'tweaks';

--- a/themes/yaru-magenta-dark/gtk.css
+++ b/themes/yaru-magenta-dark/gtk.css
@@ -1,0 +1,121 @@
+@define-color yaru_accent_bg_color #B34CB3;
+@define-color blue_1 #75d3f4;
+@define-color blue_2 #47c4f1;
+@define-color blue_3 #19B6EE;
+@define-color blue_4 #007aa6;
+@define-color blue_5 #335280;
+@define-color green_1 #5AED70;
+@define-color green_2 #47D35C;
+@define-color green_3 #34B948;
+@define-color green_4 #219E34;
+@define-color green_5 #0e8420;
+@define-color yellow_1 #FCCD87;
+@define-color yellow_2 #FBC16A;
+@define-color yellow_3 #FBB44C;
+@define-color yellow_4 #FAA82F;
+@define-color yellow_5 #F99B11;
+@define-color orange_1 #F29879;
+@define-color orange_2 #F08763;
+@define-color orange_3 #ED764D;
+@define-color orange_4 #EB6536;
+@define-color orange_5 #E95420;
+@define-color red_1 #EA485C;
+@define-color red_2 #DE374C;
+@define-color red_3 #D3273B;
+@define-color red_4 #c7162b;
+@define-color red_5 #a91224;
+@define-color purple_1 #924D8B;
+@define-color purple_2 #762572;
+@define-color purple_3 #77216F;
+@define-color purple_4 #5E2750;
+@define-color purple_5 #2C001E;
+@define-color brown_1 #E1B289;
+@define-color brown_2 #C5976E;
+@define-color brown_3 #AA7B53;
+@define-color brown_4 #8E6038;
+@define-color brown_5 #72441D;
+@define-color light_1 #FFFFFF;
+@define-color light_2 #F7F7F7;
+@define-color light_3 #CCC;
+@define-color light_4 #AEA79F;
+@define-color light_5 #878787;
+@define-color dark_1 #666666;
+@define-color dark_2 #5D5D5D;
+@define-color dark_3 #3D3D3D;
+@define-color dark_4 #181818;
+@define-color dark_5 #000000;
+/* GTK NAMED COLORS
+   ----------------
+   use responsibly! */
+@define-color accent_bg_color @yaru_accent_bg_color;
+@define-color accent_fg_color @light_1;
+@define-color accent_color @yaru_accent_bg_color;
+@define-color destructive_bg_color @red_4;
+@define-color destructive_fg_color @light_1;
+@define-color destructive_color @red_4;
+@define-color success_bg_color @green_4;
+@define-color success_fg_color @light_1;
+@define-color success_color @green_4;
+@define-color warning_bg_color @yellow_5;
+@define-color warning_fg_color @light_1;
+@define-color warning_color @yellow_5;
+@define-color error_bg_color @red_4;
+@define-color error_fg_color @light_1;
+@define-color error_color @red_4;
+@define-color window_bg_color #2c2c2c;
+@define-color window_fg_color @light_2;
+@define-color view_bg_color #1e1e1e;
+@define-color view_fg_color #ffffff;
+@define-color headerbar_bg_color #303030;
+@define-color headerbar_fg_color white;
+@define-color headerbar_backdrop_color @window_bg_color;
+@define-color card_bg_color rgba(255, 255, 255, 0.08);
+@define-color card_fg_color white;
+@define-color popover_bg_color #383838;
+@define-color popover_fg_color white;
+.sidebar {
+  background-color: @window_bg_color;
+}
+
+notebook entry {
+  background-color: mix(@view_bg_color,black,0.02);
+}
+
+popover.menu check,
+popover.menu radio {
+  transition: none;
+}
+
+levelbar > trough > block.high, levelbar > trough > block:not(.empty) {
+  background-color: @success_color;
+}
+
+
+button.suggested-action {
+  color: @success_fg_color;
+}
+
+
+button.suggested-action:not(.flat),
+button.suggested-action:checked:not(.flat) {
+  background-color: @success_bg_color;
+}
+
+
+button.flat.suggested-action {
+  color: @success_color;
+}
+
+splitbutton.suggested-action > button, splitbutton.suggested-action > menubutton > button {
+  color: @success_fg_color;
+}
+
+splitbutton.suggested-action > button, splitbutton.suggested-action > button:checked, splitbutton.suggested-action > menubutton > button, splitbutton.suggested-action > menubutton > button:checked {
+  background-color: @success_bg_color;
+}
+
+
+button,
+link {
+  font-weight: normal;
+}

--- a/themes/yaru-magenta-dark/gtk.scss
+++ b/themes/yaru-magenta-dark/gtk.scss
@@ -1,0 +1,14 @@
+// General guidelines:
+// - very unlikely you want to edit something else than _common.scss
+// - keep the number of defined colors to a minimum, use the color blending functions if
+//   you need a subtle shade
+// - if you need to inverse a color function use the @if directive to match for dark $variant
+
+$variant: 'light';
+
+@import 'palette';
+@import 'defaults';
+@import 'functions';
+@import 'colors';
+@import 'tweaks';
+

--- a/themes/yaru-magenta-dark/parse-sass.sh
+++ b/themes/yaru-magenta-dark/parse-sass.sh
@@ -1,0 +1,12 @@
+#! /bin/bash
+
+if [ ! "$(which sassc 2> /dev/null)" ]; then
+   echo sassc needs to be installed to generate the css.
+   exit 1
+fi
+
+SASSC_OPT="-M -t expanded"
+
+echo Generating the css...
+
+sassc $SASSC_OPT gtk-dark.scss gtk.css

--- a/themes/yaru-magenta/_colors.scss
+++ b/themes/yaru-magenta/_colors.scss
@@ -1,0 +1,35 @@
+$accent_bg_color: gtkcolor(accent_bg_color);
+$accent_fg_color: gtkcolor(accent_fg_color);
+$accent_color: gtkcolor(accent_color);
+
+$destructive_bg_color: gtkcolor(destructive_bg_color);
+$destructive_fg_color: gtkcolor(destructive_fg_color);
+$destructive_color: gtkcolor(destructive_color);
+
+$success_bg_color: gtkcolor(success_bg_color);
+$success_fg_color: gtkcolor(success_fg_color);
+$success_color: gtkcolor(success_color);
+
+$warning_bg_color: gtkcolor(warning_bg_color);
+$warning_fg_color: gtkcolor(warning_fg_color);
+$warning_color: gtkcolor(warning_color);
+
+$error_bg_color: gtkcolor(error_bg_color);
+$error_fg_color: gtkcolor(error_fg_color);
+$error_color: gtkcolor(error_color);
+
+$window_bg_color: gtkcolor(window_bg_color);
+$window_fg_color: gtkcolor(window_fg_color);
+
+$view_bg_color: gtkcolor(view_bg_color);
+$view_fg_color: gtkcolor(view_fg_color);
+
+$headerbar_bg_color: gtkcolor(headerbar_bg_color);
+$headerbar_fg_color: gtkcolor(headerbar_fg_color);
+$headerbar_backdrop_color: gtkcolor(headerbar_backdrop_color);
+
+$card_bg_color: gtkcolor(card_bg_color);
+$card_fg_color: gtkcolor(card_fg_color);
+
+$popover_bg_color: gtkcolor(popover_bg_color);
+$popover_fg_color: gtkcolor(popover_fg_color);

--- a/themes/yaru-magenta/_defaults.scss
+++ b/themes/yaru-magenta/_defaults.scss
@@ -1,0 +1,53 @@
+/* GTK NAMED COLORS
+   ----------------
+   use responsibly! */
+
+// Sass thinks we're using the colors in the variables as strings and may shoot
+// warning, it's innocuous and can be defeated by using #{$var}.
+
+// These are the colors apps are can override. We define the defaults here and
+// define variables for them in _colors.scss
+
+// The main accent color and the matching text value
+@define-color accent_bg_color @yaru_accent_bg_color;
+@define-color accent_fg_color @light_1;
+@define-color accent_color @yaru_accent_bg_color;
+
+// destructive-action buttons
+@define-color destructive_bg_color @red_4;
+@define-color destructive_fg_color @light_1;
+@define-color destructive_color @red_4;
+
+// Levelbars, entries, labels and infobars. These don't need text colors
+@define-color success_bg_color @green_4;
+@define-color success_fg_color @light_1;
+@define-color success_color @green_4;
+
+@define-color warning_bg_color @yellow_5;
+@define-color warning_fg_color @light_1;
+@define-color warning_color @yellow_5;
+
+@define-color error_bg_color @red_4;
+@define-color error_fg_color @light_1;
+@define-color error_color @red_4;
+
+// Window
+@define-color window_bg_color #{if($variant == 'light', #fafafa, lighten(#181818, 8%))};
+@define-color window_fg_color #{if($variant=='light', '@dark_3', '@light_2')};
+
+// Views - e.g. text view or tree view
+@define-color view_bg_color #{if($variant == 'light', #ffffff, #1e1e1e)};
+@define-color view_fg_color #{if($variant == 'light', #000000, #ffffff)};
+
+// Header bar, search bar, tab bar
+@define-color headerbar_bg_color #{if($variant == 'light', #ebebeb, #303030)};
+@define-color headerbar_fg_color #{if($variant == 'light', transparentize(black, .2), white)};
+@define-color headerbar_backdrop_color @window_bg_color;
+
+// Cards, boxed lists
+@define-color card_bg_color #{if($variant == 'light', #ffffff, transparentize(white, .92))};
+@define-color card_fg_color #{if($variant == 'light', transparentize(black, .2), white)};
+
+// Popovers
+@define-color popover_bg_color #{if($variant == 'light', #ffffff, #383838)};
+@define-color popover_fg_color #{if($variant == 'light', transparentize(black, .2), white)};

--- a/themes/yaru-magenta/_functions.scss
+++ b/themes/yaru-magenta/_functions.scss
@@ -1,0 +1,16 @@
+@function gtkalpha($c,$a) {
+  @return unquote("alpha(#{$c},#{$a})");
+}
+
+@function gtkmix($c1,$c2,$r) {
+  $ratio: 1 -  $r / 100%; // match SCSS mix()
+  @return unquote("mix(#{$c1},#{$c2},#{$ratio})");
+}
+
+@function gtkshade($c,$s) {
+  @return unquote("shade(#{$c},#{$s})");
+}
+
+@function gtkcolor($c) {
+  @return unquote("@#{$c}");
+}

--- a/themes/yaru-magenta/_palette.scss
+++ b/themes/yaru-magenta/_palette.scss
@@ -1,0 +1,110 @@
+$blue_1: #75d3f4;
+$blue_2: #47c4f1;
+$blue_3: #19B6EE; // Yaru blue
+$blue_4: #007aa6; // Yaru linkblue
+$blue_5: #335280; // Yaru darkblue
+$green_1: #5AED70;
+$green_2: #47D35C;
+$green_3: #34B948;
+$green_4: #219E34;
+$green_5: #0e8420; // Yaru green
+$yellow_1: #FCCD87;
+$yellow_2: #FBC16A;
+$yellow_3: #FBB44C;
+$yellow_4: #FAA82F;
+$yellow_5: #F99B11; // Yaru yellow
+$orange_1: #F29879;
+$orange_2: #F08763;
+$orange_3: #ED764D;
+$orange_4: #EB6536;
+$orange_5: #E95420; // Yaru orange
+$red_1: #EA485C;
+$red_2: #DE374C;
+$red_3: #D3273B;
+$red_4: #c7162b; // Yaru red
+$red_5: #a91224;
+$purple_1: #924D8B; // Yaru aubergine
+$purple_2: #762572; // Yaru purple
+$purple_3: #77216F; // Yaru light aubergine
+$purple_4: #5E2750; // Yaru mid aubergine
+$purple_5: #2C001E; // Yaru dark aubergine
+$brown_1: #E1B289;
+$brown_2: #C5976E;
+$brown_3: #AA7B53;
+$brown_4: #8E6038;
+$brown_5: #72441D;
+$light_1: #FFFFFF;
+$light_2: #F7F7F7; // Yaru porcelain
+$light_3: #CCC; // Yaru silk
+$light_4: #AEA79F; // Yaru warm gray
+$light_5: #878787; // Yaru ash
+$dark_1: #666666; // Yaru graphite
+$dark_2: #5D5D5D; // Yaru slate
+$dark_3: #3D3D3D; // Yaru inkstone
+$dark_4: #181818; // Yaru jet
+$dark_5: #000000;
+
+// Ubuntu accent colors
+$default: $orange_5;
+$bark: #787859;
+$sage: #657B69;
+$olive: #4B8501;
+$viridian: #03875B;
+$prussiangreen: #308280;
+$blue: #0073E5;
+$purple: #7764D8;
+$magenta: #B34CB3;
+$red: #DA3450;
+
+$yaru_accent_bg_color: $magenta !default;
+@define-color yaru_accent_bg_color #{$yaru_accent_bg_color};
+
+
+// Sass thinks we're using the colors in the variables as strings and may shoot
+// warning, it's innocuous and can be defeated by using #{$var}.
+
+@define-color blue_1 #{$blue_1};
+@define-color blue_2 #{$blue_2};
+@define-color blue_3 #{$blue_3};
+@define-color blue_4 #{$blue_4};
+@define-color blue_5 #{$blue_5};
+@define-color green_1 #{$green_1};
+@define-color green_2 #{$green_2};
+@define-color green_3 #{$green_3};
+@define-color green_4 #{$green_4};
+@define-color green_5 #{$green_5};
+@define-color yellow_1 #{$yellow_1};
+@define-color yellow_2 #{$yellow_2};
+@define-color yellow_3 #{$yellow_3};
+@define-color yellow_4 #{$yellow_4};
+@define-color yellow_5 #{$yellow_5};
+@define-color orange_1 #{$orange_1};
+@define-color orange_2 #{$orange_2};
+@define-color orange_3 #{$orange_3};
+@define-color orange_4 #{$orange_4};
+@define-color orange_5 #{$orange_5};
+@define-color red_1 #{$red_1};
+@define-color red_2 #{$red_2};
+@define-color red_3 #{$red_3};
+@define-color red_4 #{$red_4};
+@define-color red_5 #{$red_5};
+@define-color purple_1 #{$purple_1};
+@define-color purple_2 #{$purple_2};
+@define-color purple_3 #{$purple_3};
+@define-color purple_4 #{$purple_4};
+@define-color purple_5 #{$purple_5};
+@define-color brown_1 #{$brown_1};
+@define-color brown_2 #{$brown_2};
+@define-color brown_3 #{$brown_3};
+@define-color brown_4 #{$brown_4};
+@define-color brown_5 #{$brown_5};
+@define-color light_1 #{$light_1};
+@define-color light_2 #{$light_2};
+@define-color light_3 #{$light_3};
+@define-color light_4 #{$light_4};
+@define-color light_5 #{$light_5};
+@define-color dark_1 #{$dark_1};
+@define-color dark_2 #{$dark_2};
+@define-color dark_3 #{$dark_3};
+@define-color dark_4 #{$dark_4};
+@define-color dark_5 #{$dark_5};

--- a/themes/yaru-magenta/_tweaks.scss
+++ b/themes/yaru-magenta/_tweaks.scss
@@ -1,0 +1,73 @@
+// Reducing the amount of the palette's background colors to two
+.sidebar {
+	background-color: $window_bg_color;
+}
+
+// Entries drown if drawn on widgets with $base_color
+// Fixing this at least for notebooks, since entries on tabs is a common pattern
+// Remove this when upstream makes entries have a light border in the dark theme
+@if $variant== "dark" {
+	notebook entry {
+			background-color: gtkmix($view_bg_color, black, 98%);
+	}
+}
+
+// Fix popover wiggling effect (see #2903)
+popover.menu {
+	check,
+	radio {
+			transition: none;
+	}
+}
+
+// Use our own palette for high and not empty levelbar
+levelbar {
+	> trough {
+			> block {
+					&.high,
+					&:not(.empty) {
+							background-color: $success_color;
+					}
+			}
+	}
+}
+
+// Green suggested buttons
+%button,
+button {
+	&.suggested-action {
+			color: $success_fg_color;
+
+			&,
+			&:checked {
+					&:not(.flat) {
+							background-color: $success_bg_color;
+					}
+			}
+	}
+
+	&.flat {
+			&.suggested-action {
+					color: $success_color;
+			}
+	}
+}
+
+splitbutton {
+	&.suggested-action {
+			> button, > menubutton > button {
+					color: $success_fg_color;
+	
+					&, &:checked {
+							background-color: $success_bg_color;
+					}
+			}
+	}
+}
+
+%button,
+button,
+%link,
+link {
+	font-weight: normal;
+}

--- a/themes/yaru-magenta/gtk-dark.scss
+++ b/themes/yaru-magenta/gtk-dark.scss
@@ -1,0 +1,13 @@
+// General guidelines:
+// - very unlikely you want to edit something else than _common.scss
+// - keep the number of defined colors to a minimum, use the color blending functions if
+//   you need a subtle shade
+// - if you need to inverse a color function use the @if directive to match for dark $variant
+
+$variant: 'dark';
+
+@import 'palette';
+@import 'defaults';
+@import 'functions';
+@import 'colors';
+@import 'tweaks';

--- a/themes/yaru-magenta/gtk.css
+++ b/themes/yaru-magenta/gtk.css
@@ -1,0 +1,117 @@
+@define-color yaru_accent_bg_color #B34CB3;
+@define-color blue_1 #75d3f4;
+@define-color blue_2 #47c4f1;
+@define-color blue_3 #19B6EE;
+@define-color blue_4 #007aa6;
+@define-color blue_5 #335280;
+@define-color green_1 #5AED70;
+@define-color green_2 #47D35C;
+@define-color green_3 #34B948;
+@define-color green_4 #219E34;
+@define-color green_5 #0e8420;
+@define-color yellow_1 #FCCD87;
+@define-color yellow_2 #FBC16A;
+@define-color yellow_3 #FBB44C;
+@define-color yellow_4 #FAA82F;
+@define-color yellow_5 #F99B11;
+@define-color orange_1 #F29879;
+@define-color orange_2 #F08763;
+@define-color orange_3 #ED764D;
+@define-color orange_4 #EB6536;
+@define-color orange_5 #E95420;
+@define-color red_1 #EA485C;
+@define-color red_2 #DE374C;
+@define-color red_3 #D3273B;
+@define-color red_4 #c7162b;
+@define-color red_5 #a91224;
+@define-color purple_1 #924D8B;
+@define-color purple_2 #762572;
+@define-color purple_3 #77216F;
+@define-color purple_4 #5E2750;
+@define-color purple_5 #2C001E;
+@define-color brown_1 #E1B289;
+@define-color brown_2 #C5976E;
+@define-color brown_3 #AA7B53;
+@define-color brown_4 #8E6038;
+@define-color brown_5 #72441D;
+@define-color light_1 #FFFFFF;
+@define-color light_2 #F7F7F7;
+@define-color light_3 #CCC;
+@define-color light_4 #AEA79F;
+@define-color light_5 #878787;
+@define-color dark_1 #666666;
+@define-color dark_2 #5D5D5D;
+@define-color dark_3 #3D3D3D;
+@define-color dark_4 #181818;
+@define-color dark_5 #000000;
+/* GTK NAMED COLORS
+   ----------------
+   use responsibly! */
+@define-color accent_bg_color @yaru_accent_bg_color;
+@define-color accent_fg_color @light_1;
+@define-color accent_color @yaru_accent_bg_color;
+@define-color destructive_bg_color @red_4;
+@define-color destructive_fg_color @light_1;
+@define-color destructive_color @red_4;
+@define-color success_bg_color @green_4;
+@define-color success_fg_color @light_1;
+@define-color success_color @green_4;
+@define-color warning_bg_color @yellow_5;
+@define-color warning_fg_color @light_1;
+@define-color warning_color @yellow_5;
+@define-color error_bg_color @red_4;
+@define-color error_fg_color @light_1;
+@define-color error_color @red_4;
+@define-color window_bg_color #fafafa;
+@define-color window_fg_color @dark_3;
+@define-color view_bg_color #ffffff;
+@define-color view_fg_color #000000;
+@define-color headerbar_bg_color #ebebeb;
+@define-color headerbar_fg_color rgba(0, 0, 0, 0.8);
+@define-color headerbar_backdrop_color @window_bg_color;
+@define-color card_bg_color #ffffff;
+@define-color card_fg_color rgba(0, 0, 0, 0.8);
+@define-color popover_bg_color #ffffff;
+@define-color popover_fg_color rgba(0, 0, 0, 0.8);
+.sidebar {
+  background-color: @window_bg_color;
+}
+
+popover.menu check,
+popover.menu radio {
+  transition: none;
+}
+
+levelbar > trough > block.high, levelbar > trough > block:not(.empty) {
+  background-color: @success_color;
+}
+
+
+button.suggested-action {
+  color: @success_fg_color;
+}
+
+
+button.suggested-action:not(.flat),
+button.suggested-action:checked:not(.flat) {
+  background-color: @success_bg_color;
+}
+
+
+button.flat.suggested-action {
+  color: @success_color;
+}
+
+splitbutton.suggested-action > button, splitbutton.suggested-action > menubutton > button {
+  color: @success_fg_color;
+}
+
+splitbutton.suggested-action > button, splitbutton.suggested-action > button:checked, splitbutton.suggested-action > menubutton > button, splitbutton.suggested-action > menubutton > button:checked {
+  background-color: @success_bg_color;
+}
+
+
+button,
+link {
+  font-weight: normal;
+}

--- a/themes/yaru-magenta/gtk.scss
+++ b/themes/yaru-magenta/gtk.scss
@@ -1,0 +1,14 @@
+// General guidelines:
+// - very unlikely you want to edit something else than _common.scss
+// - keep the number of defined colors to a minimum, use the color blending functions if
+//   you need a subtle shade
+// - if you need to inverse a color function use the @if directive to match for dark $variant
+
+$variant: 'light';
+
+@import 'palette';
+@import 'defaults';
+@import 'functions';
+@import 'colors';
+@import 'tweaks';
+

--- a/themes/yaru-magenta/parse-sass.sh
+++ b/themes/yaru-magenta/parse-sass.sh
@@ -1,0 +1,12 @@
+#! /bin/bash
+
+if [ ! "$(which sassc 2> /dev/null)" ]; then
+   echo sassc needs to be installed to generate the css.
+   exit 1
+fi
+
+SASSC_OPT="-M -t expanded"
+
+echo Generating the css...
+
+sassc $SASSC_OPT gtk.scss gtk.css

--- a/themes/yaru-olive-dark/_colors.scss
+++ b/themes/yaru-olive-dark/_colors.scss
@@ -1,0 +1,35 @@
+$accent_bg_color: gtkcolor(accent_bg_color);
+$accent_fg_color: gtkcolor(accent_fg_color);
+$accent_color: gtkcolor(accent_color);
+
+$destructive_bg_color: gtkcolor(destructive_bg_color);
+$destructive_fg_color: gtkcolor(destructive_fg_color);
+$destructive_color: gtkcolor(destructive_color);
+
+$success_bg_color: gtkcolor(success_bg_color);
+$success_fg_color: gtkcolor(success_fg_color);
+$success_color: gtkcolor(success_color);
+
+$warning_bg_color: gtkcolor(warning_bg_color);
+$warning_fg_color: gtkcolor(warning_fg_color);
+$warning_color: gtkcolor(warning_color);
+
+$error_bg_color: gtkcolor(error_bg_color);
+$error_fg_color: gtkcolor(error_fg_color);
+$error_color: gtkcolor(error_color);
+
+$window_bg_color: gtkcolor(window_bg_color);
+$window_fg_color: gtkcolor(window_fg_color);
+
+$view_bg_color: gtkcolor(view_bg_color);
+$view_fg_color: gtkcolor(view_fg_color);
+
+$headerbar_bg_color: gtkcolor(headerbar_bg_color);
+$headerbar_fg_color: gtkcolor(headerbar_fg_color);
+$headerbar_backdrop_color: gtkcolor(headerbar_backdrop_color);
+
+$card_bg_color: gtkcolor(card_bg_color);
+$card_fg_color: gtkcolor(card_fg_color);
+
+$popover_bg_color: gtkcolor(popover_bg_color);
+$popover_fg_color: gtkcolor(popover_fg_color);

--- a/themes/yaru-olive-dark/_defaults.scss
+++ b/themes/yaru-olive-dark/_defaults.scss
@@ -1,0 +1,53 @@
+/* GTK NAMED COLORS
+   ----------------
+   use responsibly! */
+
+// Sass thinks we're using the colors in the variables as strings and may shoot
+// warning, it's innocuous and can be defeated by using #{$var}.
+
+// These are the colors apps are can override. We define the defaults here and
+// define variables for them in _colors.scss
+
+// The main accent color and the matching text value
+@define-color accent_bg_color @yaru_accent_bg_color;
+@define-color accent_fg_color @light_1;
+@define-color accent_color @yaru_accent_bg_color;
+
+// destructive-action buttons
+@define-color destructive_bg_color @red_4;
+@define-color destructive_fg_color @light_1;
+@define-color destructive_color @red_4;
+
+// Levelbars, entries, labels and infobars. These don't need text colors
+@define-color success_bg_color @green_4;
+@define-color success_fg_color @light_1;
+@define-color success_color @green_4;
+
+@define-color warning_bg_color @yellow_5;
+@define-color warning_fg_color @light_1;
+@define-color warning_color @yellow_5;
+
+@define-color error_bg_color @red_4;
+@define-color error_fg_color @light_1;
+@define-color error_color @red_4;
+
+// Window
+@define-color window_bg_color #{if($variant == 'light', #fafafa, lighten(#181818, 8%))};
+@define-color window_fg_color #{if($variant=='light', '@dark_3', '@light_2')};
+
+// Views - e.g. text view or tree view
+@define-color view_bg_color #{if($variant == 'light', #ffffff, #1e1e1e)};
+@define-color view_fg_color #{if($variant == 'light', #000000, #ffffff)};
+
+// Header bar, search bar, tab bar
+@define-color headerbar_bg_color #{if($variant == 'light', #ebebeb, #303030)};
+@define-color headerbar_fg_color #{if($variant == 'light', transparentize(black, .2), white)};
+@define-color headerbar_backdrop_color @window_bg_color;
+
+// Cards, boxed lists
+@define-color card_bg_color #{if($variant == 'light', #ffffff, transparentize(white, .92))};
+@define-color card_fg_color #{if($variant == 'light', transparentize(black, .2), white)};
+
+// Popovers
+@define-color popover_bg_color #{if($variant == 'light', #ffffff, #383838)};
+@define-color popover_fg_color #{if($variant == 'light', transparentize(black, .2), white)};

--- a/themes/yaru-olive-dark/_functions.scss
+++ b/themes/yaru-olive-dark/_functions.scss
@@ -1,0 +1,16 @@
+@function gtkalpha($c,$a) {
+  @return unquote("alpha(#{$c},#{$a})");
+}
+
+@function gtkmix($c1,$c2,$r) {
+  $ratio: 1 -  $r / 100%; // match SCSS mix()
+  @return unquote("mix(#{$c1},#{$c2},#{$ratio})");
+}
+
+@function gtkshade($c,$s) {
+  @return unquote("shade(#{$c},#{$s})");
+}
+
+@function gtkcolor($c) {
+  @return unquote("@#{$c}");
+}

--- a/themes/yaru-olive-dark/_palette.scss
+++ b/themes/yaru-olive-dark/_palette.scss
@@ -1,0 +1,110 @@
+$blue_1: #75d3f4;
+$blue_2: #47c4f1;
+$blue_3: #19B6EE; // Yaru blue
+$blue_4: #007aa6; // Yaru linkblue
+$blue_5: #335280; // Yaru darkblue
+$green_1: #5AED70;
+$green_2: #47D35C;
+$green_3: #34B948;
+$green_4: #219E34;
+$green_5: #0e8420; // Yaru green
+$yellow_1: #FCCD87;
+$yellow_2: #FBC16A;
+$yellow_3: #FBB44C;
+$yellow_4: #FAA82F;
+$yellow_5: #F99B11; // Yaru yellow
+$orange_1: #F29879;
+$orange_2: #F08763;
+$orange_3: #ED764D;
+$orange_4: #EB6536;
+$orange_5: #E95420; // Yaru orange
+$red_1: #EA485C;
+$red_2: #DE374C;
+$red_3: #D3273B;
+$red_4: #c7162b; // Yaru red
+$red_5: #a91224;
+$purple_1: #924D8B; // Yaru aubergine
+$purple_2: #762572; // Yaru purple
+$purple_3: #77216F; // Yaru light aubergine
+$purple_4: #5E2750; // Yaru mid aubergine
+$purple_5: #2C001E; // Yaru dark aubergine
+$brown_1: #E1B289;
+$brown_2: #C5976E;
+$brown_3: #AA7B53;
+$brown_4: #8E6038;
+$brown_5: #72441D;
+$light_1: #FFFFFF;
+$light_2: #F7F7F7; // Yaru porcelain
+$light_3: #CCC; // Yaru silk
+$light_4: #AEA79F; // Yaru warm gray
+$light_5: #878787; // Yaru ash
+$dark_1: #666666; // Yaru graphite
+$dark_2: #5D5D5D; // Yaru slate
+$dark_3: #3D3D3D; // Yaru inkstone
+$dark_4: #181818; // Yaru jet
+$dark_5: #000000;
+
+// Ubuntu accent colors
+$default: $orange_5;
+$bark: #787859;
+$sage: #657B69;
+$olive: #4B8501;
+$viridian: #03875B;
+$prussiangreen: #308280;
+$blue: #0073E5;
+$purple: #7764D8;
+$magenta: #B34CB3;
+$red: #DA3450;
+
+$yaru_accent_bg_color: $olive !default;
+@define-color yaru_accent_bg_color #{$yaru_accent_bg_color};
+
+
+// Sass thinks we're using the colors in the variables as strings and may shoot
+// warning, it's innocuous and can be defeated by using #{$var}.
+
+@define-color blue_1 #{$blue_1};
+@define-color blue_2 #{$blue_2};
+@define-color blue_3 #{$blue_3};
+@define-color blue_4 #{$blue_4};
+@define-color blue_5 #{$blue_5};
+@define-color green_1 #{$green_1};
+@define-color green_2 #{$green_2};
+@define-color green_3 #{$green_3};
+@define-color green_4 #{$green_4};
+@define-color green_5 #{$green_5};
+@define-color yellow_1 #{$yellow_1};
+@define-color yellow_2 #{$yellow_2};
+@define-color yellow_3 #{$yellow_3};
+@define-color yellow_4 #{$yellow_4};
+@define-color yellow_5 #{$yellow_5};
+@define-color orange_1 #{$orange_1};
+@define-color orange_2 #{$orange_2};
+@define-color orange_3 #{$orange_3};
+@define-color orange_4 #{$orange_4};
+@define-color orange_5 #{$orange_5};
+@define-color red_1 #{$red_1};
+@define-color red_2 #{$red_2};
+@define-color red_3 #{$red_3};
+@define-color red_4 #{$red_4};
+@define-color red_5 #{$red_5};
+@define-color purple_1 #{$purple_1};
+@define-color purple_2 #{$purple_2};
+@define-color purple_3 #{$purple_3};
+@define-color purple_4 #{$purple_4};
+@define-color purple_5 #{$purple_5};
+@define-color brown_1 #{$brown_1};
+@define-color brown_2 #{$brown_2};
+@define-color brown_3 #{$brown_3};
+@define-color brown_4 #{$brown_4};
+@define-color brown_5 #{$brown_5};
+@define-color light_1 #{$light_1};
+@define-color light_2 #{$light_2};
+@define-color light_3 #{$light_3};
+@define-color light_4 #{$light_4};
+@define-color light_5 #{$light_5};
+@define-color dark_1 #{$dark_1};
+@define-color dark_2 #{$dark_2};
+@define-color dark_3 #{$dark_3};
+@define-color dark_4 #{$dark_4};
+@define-color dark_5 #{$dark_5};

--- a/themes/yaru-olive-dark/_tweaks.scss
+++ b/themes/yaru-olive-dark/_tweaks.scss
@@ -1,0 +1,73 @@
+// Reducing the amount of the palette's background colors to two
+.sidebar {
+	background-color: $window_bg_color;
+}
+
+// Entries drown if drawn on widgets with $base_color
+// Fixing this at least for notebooks, since entries on tabs is a common pattern
+// Remove this when upstream makes entries have a light border in the dark theme
+@if $variant== "dark" {
+	notebook entry {
+			background-color: gtkmix($view_bg_color, black, 98%);
+	}
+}
+
+// Fix popover wiggling effect (see #2903)
+popover.menu {
+	check,
+	radio {
+			transition: none;
+	}
+}
+
+// Use our own palette for high and not empty levelbar
+levelbar {
+	> trough {
+			> block {
+					&.high,
+					&:not(.empty) {
+							background-color: $success_color;
+					}
+			}
+	}
+}
+
+// Green suggested buttons
+%button,
+button {
+	&.suggested-action {
+			color: $success_fg_color;
+
+			&,
+			&:checked {
+					&:not(.flat) {
+							background-color: $success_bg_color;
+					}
+			}
+	}
+
+	&.flat {
+			&.suggested-action {
+					color: $success_color;
+			}
+	}
+}
+
+splitbutton {
+	&.suggested-action {
+			> button, > menubutton > button {
+					color: $success_fg_color;
+	
+					&, &:checked {
+							background-color: $success_bg_color;
+					}
+			}
+	}
+}
+
+%button,
+button,
+%link,
+link {
+	font-weight: normal;
+}

--- a/themes/yaru-olive-dark/gtk-dark.scss
+++ b/themes/yaru-olive-dark/gtk-dark.scss
@@ -1,0 +1,13 @@
+// General guidelines:
+// - very unlikely you want to edit something else than _common.scss
+// - keep the number of defined colors to a minimum, use the color blending functions if
+//   you need a subtle shade
+// - if you need to inverse a color function use the @if directive to match for dark $variant
+
+$variant: 'dark';
+
+@import 'palette';
+@import 'defaults';
+@import 'functions';
+@import 'colors';
+@import 'tweaks';

--- a/themes/yaru-olive-dark/gtk.css
+++ b/themes/yaru-olive-dark/gtk.css
@@ -1,0 +1,121 @@
+@define-color yaru_accent_bg_color #4B8501;
+@define-color blue_1 #75d3f4;
+@define-color blue_2 #47c4f1;
+@define-color blue_3 #19B6EE;
+@define-color blue_4 #007aa6;
+@define-color blue_5 #335280;
+@define-color green_1 #5AED70;
+@define-color green_2 #47D35C;
+@define-color green_3 #34B948;
+@define-color green_4 #219E34;
+@define-color green_5 #0e8420;
+@define-color yellow_1 #FCCD87;
+@define-color yellow_2 #FBC16A;
+@define-color yellow_3 #FBB44C;
+@define-color yellow_4 #FAA82F;
+@define-color yellow_5 #F99B11;
+@define-color orange_1 #F29879;
+@define-color orange_2 #F08763;
+@define-color orange_3 #ED764D;
+@define-color orange_4 #EB6536;
+@define-color orange_5 #E95420;
+@define-color red_1 #EA485C;
+@define-color red_2 #DE374C;
+@define-color red_3 #D3273B;
+@define-color red_4 #c7162b;
+@define-color red_5 #a91224;
+@define-color purple_1 #924D8B;
+@define-color purple_2 #762572;
+@define-color purple_3 #77216F;
+@define-color purple_4 #5E2750;
+@define-color purple_5 #2C001E;
+@define-color brown_1 #E1B289;
+@define-color brown_2 #C5976E;
+@define-color brown_3 #AA7B53;
+@define-color brown_4 #8E6038;
+@define-color brown_5 #72441D;
+@define-color light_1 #FFFFFF;
+@define-color light_2 #F7F7F7;
+@define-color light_3 #CCC;
+@define-color light_4 #AEA79F;
+@define-color light_5 #878787;
+@define-color dark_1 #666666;
+@define-color dark_2 #5D5D5D;
+@define-color dark_3 #3D3D3D;
+@define-color dark_4 #181818;
+@define-color dark_5 #000000;
+/* GTK NAMED COLORS
+   ----------------
+   use responsibly! */
+@define-color accent_bg_color @yaru_accent_bg_color;
+@define-color accent_fg_color @light_1;
+@define-color accent_color @yaru_accent_bg_color;
+@define-color destructive_bg_color @red_4;
+@define-color destructive_fg_color @light_1;
+@define-color destructive_color @red_4;
+@define-color success_bg_color @green_4;
+@define-color success_fg_color @light_1;
+@define-color success_color @green_4;
+@define-color warning_bg_color @yellow_5;
+@define-color warning_fg_color @light_1;
+@define-color warning_color @yellow_5;
+@define-color error_bg_color @red_4;
+@define-color error_fg_color @light_1;
+@define-color error_color @red_4;
+@define-color window_bg_color #2c2c2c;
+@define-color window_fg_color @light_2;
+@define-color view_bg_color #1e1e1e;
+@define-color view_fg_color #ffffff;
+@define-color headerbar_bg_color #303030;
+@define-color headerbar_fg_color white;
+@define-color headerbar_backdrop_color @window_bg_color;
+@define-color card_bg_color rgba(255, 255, 255, 0.08);
+@define-color card_fg_color white;
+@define-color popover_bg_color #383838;
+@define-color popover_fg_color white;
+.sidebar {
+  background-color: @window_bg_color;
+}
+
+notebook entry {
+  background-color: mix(@view_bg_color,black,0.02);
+}
+
+popover.menu check,
+popover.menu radio {
+  transition: none;
+}
+
+levelbar > trough > block.high, levelbar > trough > block:not(.empty) {
+  background-color: @success_color;
+}
+
+
+button.suggested-action {
+  color: @success_fg_color;
+}
+
+
+button.suggested-action:not(.flat),
+button.suggested-action:checked:not(.flat) {
+  background-color: @success_bg_color;
+}
+
+
+button.flat.suggested-action {
+  color: @success_color;
+}
+
+splitbutton.suggested-action > button, splitbutton.suggested-action > menubutton > button {
+  color: @success_fg_color;
+}
+
+splitbutton.suggested-action > button, splitbutton.suggested-action > button:checked, splitbutton.suggested-action > menubutton > button, splitbutton.suggested-action > menubutton > button:checked {
+  background-color: @success_bg_color;
+}
+
+
+button,
+link {
+  font-weight: normal;
+}

--- a/themes/yaru-olive-dark/gtk.scss
+++ b/themes/yaru-olive-dark/gtk.scss
@@ -1,0 +1,14 @@
+// General guidelines:
+// - very unlikely you want to edit something else than _common.scss
+// - keep the number of defined colors to a minimum, use the color blending functions if
+//   you need a subtle shade
+// - if you need to inverse a color function use the @if directive to match for dark $variant
+
+$variant: 'light';
+
+@import 'palette';
+@import 'defaults';
+@import 'functions';
+@import 'colors';
+@import 'tweaks';
+

--- a/themes/yaru-olive-dark/parse-sass.sh
+++ b/themes/yaru-olive-dark/parse-sass.sh
@@ -1,0 +1,12 @@
+#! /bin/bash
+
+if [ ! "$(which sassc 2> /dev/null)" ]; then
+   echo sassc needs to be installed to generate the css.
+   exit 1
+fi
+
+SASSC_OPT="-M -t expanded"
+
+echo Generating the css...
+
+sassc $SASSC_OPT gtk-dark.scss gtk.css

--- a/themes/yaru-olive/_colors.scss
+++ b/themes/yaru-olive/_colors.scss
@@ -1,0 +1,35 @@
+$accent_bg_color: gtkcolor(accent_bg_color);
+$accent_fg_color: gtkcolor(accent_fg_color);
+$accent_color: gtkcolor(accent_color);
+
+$destructive_bg_color: gtkcolor(destructive_bg_color);
+$destructive_fg_color: gtkcolor(destructive_fg_color);
+$destructive_color: gtkcolor(destructive_color);
+
+$success_bg_color: gtkcolor(success_bg_color);
+$success_fg_color: gtkcolor(success_fg_color);
+$success_color: gtkcolor(success_color);
+
+$warning_bg_color: gtkcolor(warning_bg_color);
+$warning_fg_color: gtkcolor(warning_fg_color);
+$warning_color: gtkcolor(warning_color);
+
+$error_bg_color: gtkcolor(error_bg_color);
+$error_fg_color: gtkcolor(error_fg_color);
+$error_color: gtkcolor(error_color);
+
+$window_bg_color: gtkcolor(window_bg_color);
+$window_fg_color: gtkcolor(window_fg_color);
+
+$view_bg_color: gtkcolor(view_bg_color);
+$view_fg_color: gtkcolor(view_fg_color);
+
+$headerbar_bg_color: gtkcolor(headerbar_bg_color);
+$headerbar_fg_color: gtkcolor(headerbar_fg_color);
+$headerbar_backdrop_color: gtkcolor(headerbar_backdrop_color);
+
+$card_bg_color: gtkcolor(card_bg_color);
+$card_fg_color: gtkcolor(card_fg_color);
+
+$popover_bg_color: gtkcolor(popover_bg_color);
+$popover_fg_color: gtkcolor(popover_fg_color);

--- a/themes/yaru-olive/_defaults.scss
+++ b/themes/yaru-olive/_defaults.scss
@@ -1,0 +1,53 @@
+/* GTK NAMED COLORS
+   ----------------
+   use responsibly! */
+
+// Sass thinks we're using the colors in the variables as strings and may shoot
+// warning, it's innocuous and can be defeated by using #{$var}.
+
+// These are the colors apps are can override. We define the defaults here and
+// define variables for them in _colors.scss
+
+// The main accent color and the matching text value
+@define-color accent_bg_color @yaru_accent_bg_color;
+@define-color accent_fg_color @light_1;
+@define-color accent_color @yaru_accent_bg_color;
+
+// destructive-action buttons
+@define-color destructive_bg_color @red_4;
+@define-color destructive_fg_color @light_1;
+@define-color destructive_color @red_4;
+
+// Levelbars, entries, labels and infobars. These don't need text colors
+@define-color success_bg_color @green_4;
+@define-color success_fg_color @light_1;
+@define-color success_color @green_4;
+
+@define-color warning_bg_color @yellow_5;
+@define-color warning_fg_color @light_1;
+@define-color warning_color @yellow_5;
+
+@define-color error_bg_color @red_4;
+@define-color error_fg_color @light_1;
+@define-color error_color @red_4;
+
+// Window
+@define-color window_bg_color #{if($variant == 'light', #fafafa, lighten(#181818, 8%))};
+@define-color window_fg_color #{if($variant=='light', '@dark_3', '@light_2')};
+
+// Views - e.g. text view or tree view
+@define-color view_bg_color #{if($variant == 'light', #ffffff, #1e1e1e)};
+@define-color view_fg_color #{if($variant == 'light', #000000, #ffffff)};
+
+// Header bar, search bar, tab bar
+@define-color headerbar_bg_color #{if($variant == 'light', #ebebeb, #303030)};
+@define-color headerbar_fg_color #{if($variant == 'light', transparentize(black, .2), white)};
+@define-color headerbar_backdrop_color @window_bg_color;
+
+// Cards, boxed lists
+@define-color card_bg_color #{if($variant == 'light', #ffffff, transparentize(white, .92))};
+@define-color card_fg_color #{if($variant == 'light', transparentize(black, .2), white)};
+
+// Popovers
+@define-color popover_bg_color #{if($variant == 'light', #ffffff, #383838)};
+@define-color popover_fg_color #{if($variant == 'light', transparentize(black, .2), white)};

--- a/themes/yaru-olive/_functions.scss
+++ b/themes/yaru-olive/_functions.scss
@@ -1,0 +1,16 @@
+@function gtkalpha($c,$a) {
+  @return unquote("alpha(#{$c},#{$a})");
+}
+
+@function gtkmix($c1,$c2,$r) {
+  $ratio: 1 -  $r / 100%; // match SCSS mix()
+  @return unquote("mix(#{$c1},#{$c2},#{$ratio})");
+}
+
+@function gtkshade($c,$s) {
+  @return unquote("shade(#{$c},#{$s})");
+}
+
+@function gtkcolor($c) {
+  @return unquote("@#{$c}");
+}

--- a/themes/yaru-olive/_palette.scss
+++ b/themes/yaru-olive/_palette.scss
@@ -1,0 +1,110 @@
+$blue_1: #75d3f4;
+$blue_2: #47c4f1;
+$blue_3: #19B6EE; // Yaru blue
+$blue_4: #007aa6; // Yaru linkblue
+$blue_5: #335280; // Yaru darkblue
+$green_1: #5AED70;
+$green_2: #47D35C;
+$green_3: #34B948;
+$green_4: #219E34;
+$green_5: #0e8420; // Yaru green
+$yellow_1: #FCCD87;
+$yellow_2: #FBC16A;
+$yellow_3: #FBB44C;
+$yellow_4: #FAA82F;
+$yellow_5: #F99B11; // Yaru yellow
+$orange_1: #F29879;
+$orange_2: #F08763;
+$orange_3: #ED764D;
+$orange_4: #EB6536;
+$orange_5: #E95420; // Yaru orange
+$red_1: #EA485C;
+$red_2: #DE374C;
+$red_3: #D3273B;
+$red_4: #c7162b; // Yaru red
+$red_5: #a91224;
+$purple_1: #924D8B; // Yaru aubergine
+$purple_2: #762572; // Yaru purple
+$purple_3: #77216F; // Yaru light aubergine
+$purple_4: #5E2750; // Yaru mid aubergine
+$purple_5: #2C001E; // Yaru dark aubergine
+$brown_1: #E1B289;
+$brown_2: #C5976E;
+$brown_3: #AA7B53;
+$brown_4: #8E6038;
+$brown_5: #72441D;
+$light_1: #FFFFFF;
+$light_2: #F7F7F7; // Yaru porcelain
+$light_3: #CCC; // Yaru silk
+$light_4: #AEA79F; // Yaru warm gray
+$light_5: #878787; // Yaru ash
+$dark_1: #666666; // Yaru graphite
+$dark_2: #5D5D5D; // Yaru slate
+$dark_3: #3D3D3D; // Yaru inkstone
+$dark_4: #181818; // Yaru jet
+$dark_5: #000000;
+
+// Ubuntu accent colors
+$default: $orange_5;
+$bark: #787859;
+$sage: #657B69;
+$olive: #4B8501;
+$viridian: #03875B;
+$prussiangreen: #308280;
+$blue: #0073E5;
+$purple: #7764D8;
+$magenta: #B34CB3;
+$red: #DA3450;
+
+$yaru_accent_bg_color: $olive !default;
+@define-color yaru_accent_bg_color #{$yaru_accent_bg_color};
+
+
+// Sass thinks we're using the colors in the variables as strings and may shoot
+// warning, it's innocuous and can be defeated by using #{$var}.
+
+@define-color blue_1 #{$blue_1};
+@define-color blue_2 #{$blue_2};
+@define-color blue_3 #{$blue_3};
+@define-color blue_4 #{$blue_4};
+@define-color blue_5 #{$blue_5};
+@define-color green_1 #{$green_1};
+@define-color green_2 #{$green_2};
+@define-color green_3 #{$green_3};
+@define-color green_4 #{$green_4};
+@define-color green_5 #{$green_5};
+@define-color yellow_1 #{$yellow_1};
+@define-color yellow_2 #{$yellow_2};
+@define-color yellow_3 #{$yellow_3};
+@define-color yellow_4 #{$yellow_4};
+@define-color yellow_5 #{$yellow_5};
+@define-color orange_1 #{$orange_1};
+@define-color orange_2 #{$orange_2};
+@define-color orange_3 #{$orange_3};
+@define-color orange_4 #{$orange_4};
+@define-color orange_5 #{$orange_5};
+@define-color red_1 #{$red_1};
+@define-color red_2 #{$red_2};
+@define-color red_3 #{$red_3};
+@define-color red_4 #{$red_4};
+@define-color red_5 #{$red_5};
+@define-color purple_1 #{$purple_1};
+@define-color purple_2 #{$purple_2};
+@define-color purple_3 #{$purple_3};
+@define-color purple_4 #{$purple_4};
+@define-color purple_5 #{$purple_5};
+@define-color brown_1 #{$brown_1};
+@define-color brown_2 #{$brown_2};
+@define-color brown_3 #{$brown_3};
+@define-color brown_4 #{$brown_4};
+@define-color brown_5 #{$brown_5};
+@define-color light_1 #{$light_1};
+@define-color light_2 #{$light_2};
+@define-color light_3 #{$light_3};
+@define-color light_4 #{$light_4};
+@define-color light_5 #{$light_5};
+@define-color dark_1 #{$dark_1};
+@define-color dark_2 #{$dark_2};
+@define-color dark_3 #{$dark_3};
+@define-color dark_4 #{$dark_4};
+@define-color dark_5 #{$dark_5};

--- a/themes/yaru-olive/_tweaks.scss
+++ b/themes/yaru-olive/_tweaks.scss
@@ -1,0 +1,73 @@
+// Reducing the amount of the palette's background colors to two
+.sidebar {
+	background-color: $window_bg_color;
+}
+
+// Entries drown if drawn on widgets with $base_color
+// Fixing this at least for notebooks, since entries on tabs is a common pattern
+// Remove this when upstream makes entries have a light border in the dark theme
+@if $variant== "dark" {
+	notebook entry {
+			background-color: gtkmix($view_bg_color, black, 98%);
+	}
+}
+
+// Fix popover wiggling effect (see #2903)
+popover.menu {
+	check,
+	radio {
+			transition: none;
+	}
+}
+
+// Use our own palette for high and not empty levelbar
+levelbar {
+	> trough {
+			> block {
+					&.high,
+					&:not(.empty) {
+							background-color: $success_color;
+					}
+			}
+	}
+}
+
+// Green suggested buttons
+%button,
+button {
+	&.suggested-action {
+			color: $success_fg_color;
+
+			&,
+			&:checked {
+					&:not(.flat) {
+							background-color: $success_bg_color;
+					}
+			}
+	}
+
+	&.flat {
+			&.suggested-action {
+					color: $success_color;
+			}
+	}
+}
+
+splitbutton {
+	&.suggested-action {
+			> button, > menubutton > button {
+					color: $success_fg_color;
+	
+					&, &:checked {
+							background-color: $success_bg_color;
+					}
+			}
+	}
+}
+
+%button,
+button,
+%link,
+link {
+	font-weight: normal;
+}

--- a/themes/yaru-olive/gtk-dark.scss
+++ b/themes/yaru-olive/gtk-dark.scss
@@ -1,0 +1,13 @@
+// General guidelines:
+// - very unlikely you want to edit something else than _common.scss
+// - keep the number of defined colors to a minimum, use the color blending functions if
+//   you need a subtle shade
+// - if you need to inverse a color function use the @if directive to match for dark $variant
+
+$variant: 'dark';
+
+@import 'palette';
+@import 'defaults';
+@import 'functions';
+@import 'colors';
+@import 'tweaks';

--- a/themes/yaru-olive/gtk.css
+++ b/themes/yaru-olive/gtk.css
@@ -1,0 +1,117 @@
+@define-color yaru_accent_bg_color #4B8501;
+@define-color blue_1 #75d3f4;
+@define-color blue_2 #47c4f1;
+@define-color blue_3 #19B6EE;
+@define-color blue_4 #007aa6;
+@define-color blue_5 #335280;
+@define-color green_1 #5AED70;
+@define-color green_2 #47D35C;
+@define-color green_3 #34B948;
+@define-color green_4 #219E34;
+@define-color green_5 #0e8420;
+@define-color yellow_1 #FCCD87;
+@define-color yellow_2 #FBC16A;
+@define-color yellow_3 #FBB44C;
+@define-color yellow_4 #FAA82F;
+@define-color yellow_5 #F99B11;
+@define-color orange_1 #F29879;
+@define-color orange_2 #F08763;
+@define-color orange_3 #ED764D;
+@define-color orange_4 #EB6536;
+@define-color orange_5 #E95420;
+@define-color red_1 #EA485C;
+@define-color red_2 #DE374C;
+@define-color red_3 #D3273B;
+@define-color red_4 #c7162b;
+@define-color red_5 #a91224;
+@define-color purple_1 #924D8B;
+@define-color purple_2 #762572;
+@define-color purple_3 #77216F;
+@define-color purple_4 #5E2750;
+@define-color purple_5 #2C001E;
+@define-color brown_1 #E1B289;
+@define-color brown_2 #C5976E;
+@define-color brown_3 #AA7B53;
+@define-color brown_4 #8E6038;
+@define-color brown_5 #72441D;
+@define-color light_1 #FFFFFF;
+@define-color light_2 #F7F7F7;
+@define-color light_3 #CCC;
+@define-color light_4 #AEA79F;
+@define-color light_5 #878787;
+@define-color dark_1 #666666;
+@define-color dark_2 #5D5D5D;
+@define-color dark_3 #3D3D3D;
+@define-color dark_4 #181818;
+@define-color dark_5 #000000;
+/* GTK NAMED COLORS
+   ----------------
+   use responsibly! */
+@define-color accent_bg_color @yaru_accent_bg_color;
+@define-color accent_fg_color @light_1;
+@define-color accent_color @yaru_accent_bg_color;
+@define-color destructive_bg_color @red_4;
+@define-color destructive_fg_color @light_1;
+@define-color destructive_color @red_4;
+@define-color success_bg_color @green_4;
+@define-color success_fg_color @light_1;
+@define-color success_color @green_4;
+@define-color warning_bg_color @yellow_5;
+@define-color warning_fg_color @light_1;
+@define-color warning_color @yellow_5;
+@define-color error_bg_color @red_4;
+@define-color error_fg_color @light_1;
+@define-color error_color @red_4;
+@define-color window_bg_color #fafafa;
+@define-color window_fg_color @dark_3;
+@define-color view_bg_color #ffffff;
+@define-color view_fg_color #000000;
+@define-color headerbar_bg_color #ebebeb;
+@define-color headerbar_fg_color rgba(0, 0, 0, 0.8);
+@define-color headerbar_backdrop_color @window_bg_color;
+@define-color card_bg_color #ffffff;
+@define-color card_fg_color rgba(0, 0, 0, 0.8);
+@define-color popover_bg_color #ffffff;
+@define-color popover_fg_color rgba(0, 0, 0, 0.8);
+.sidebar {
+  background-color: @window_bg_color;
+}
+
+popover.menu check,
+popover.menu radio {
+  transition: none;
+}
+
+levelbar > trough > block.high, levelbar > trough > block:not(.empty) {
+  background-color: @success_color;
+}
+
+
+button.suggested-action {
+  color: @success_fg_color;
+}
+
+
+button.suggested-action:not(.flat),
+button.suggested-action:checked:not(.flat) {
+  background-color: @success_bg_color;
+}
+
+
+button.flat.suggested-action {
+  color: @success_color;
+}
+
+splitbutton.suggested-action > button, splitbutton.suggested-action > menubutton > button {
+  color: @success_fg_color;
+}
+
+splitbutton.suggested-action > button, splitbutton.suggested-action > button:checked, splitbutton.suggested-action > menubutton > button, splitbutton.suggested-action > menubutton > button:checked {
+  background-color: @success_bg_color;
+}
+
+
+button,
+link {
+  font-weight: normal;
+}

--- a/themes/yaru-olive/gtk.scss
+++ b/themes/yaru-olive/gtk.scss
@@ -1,0 +1,14 @@
+// General guidelines:
+// - very unlikely you want to edit something else than _common.scss
+// - keep the number of defined colors to a minimum, use the color blending functions if
+//   you need a subtle shade
+// - if you need to inverse a color function use the @if directive to match for dark $variant
+
+$variant: 'light';
+
+@import 'palette';
+@import 'defaults';
+@import 'functions';
+@import 'colors';
+@import 'tweaks';
+

--- a/themes/yaru-olive/parse-sass.sh
+++ b/themes/yaru-olive/parse-sass.sh
@@ -1,0 +1,12 @@
+#! /bin/bash
+
+if [ ! "$(which sassc 2> /dev/null)" ]; then
+   echo sassc needs to be installed to generate the css.
+   exit 1
+fi
+
+SASSC_OPT="-M -t expanded"
+
+echo Generating the css...
+
+sassc $SASSC_OPT gtk.scss gtk.css

--- a/themes/yaru-prussiangreen-dark/_colors.scss
+++ b/themes/yaru-prussiangreen-dark/_colors.scss
@@ -1,0 +1,35 @@
+$accent_bg_color: gtkcolor(accent_bg_color);
+$accent_fg_color: gtkcolor(accent_fg_color);
+$accent_color: gtkcolor(accent_color);
+
+$destructive_bg_color: gtkcolor(destructive_bg_color);
+$destructive_fg_color: gtkcolor(destructive_fg_color);
+$destructive_color: gtkcolor(destructive_color);
+
+$success_bg_color: gtkcolor(success_bg_color);
+$success_fg_color: gtkcolor(success_fg_color);
+$success_color: gtkcolor(success_color);
+
+$warning_bg_color: gtkcolor(warning_bg_color);
+$warning_fg_color: gtkcolor(warning_fg_color);
+$warning_color: gtkcolor(warning_color);
+
+$error_bg_color: gtkcolor(error_bg_color);
+$error_fg_color: gtkcolor(error_fg_color);
+$error_color: gtkcolor(error_color);
+
+$window_bg_color: gtkcolor(window_bg_color);
+$window_fg_color: gtkcolor(window_fg_color);
+
+$view_bg_color: gtkcolor(view_bg_color);
+$view_fg_color: gtkcolor(view_fg_color);
+
+$headerbar_bg_color: gtkcolor(headerbar_bg_color);
+$headerbar_fg_color: gtkcolor(headerbar_fg_color);
+$headerbar_backdrop_color: gtkcolor(headerbar_backdrop_color);
+
+$card_bg_color: gtkcolor(card_bg_color);
+$card_fg_color: gtkcolor(card_fg_color);
+
+$popover_bg_color: gtkcolor(popover_bg_color);
+$popover_fg_color: gtkcolor(popover_fg_color);

--- a/themes/yaru-prussiangreen-dark/_defaults.scss
+++ b/themes/yaru-prussiangreen-dark/_defaults.scss
@@ -1,0 +1,53 @@
+/* GTK NAMED COLORS
+   ----------------
+   use responsibly! */
+
+// Sass thinks we're using the colors in the variables as strings and may shoot
+// warning, it's innocuous and can be defeated by using #{$var}.
+
+// These are the colors apps are can override. We define the defaults here and
+// define variables for them in _colors.scss
+
+// The main accent color and the matching text value
+@define-color accent_bg_color @yaru_accent_bg_color;
+@define-color accent_fg_color @light_1;
+@define-color accent_color @yaru_accent_bg_color;
+
+// destructive-action buttons
+@define-color destructive_bg_color @red_4;
+@define-color destructive_fg_color @light_1;
+@define-color destructive_color @red_4;
+
+// Levelbars, entries, labels and infobars. These don't need text colors
+@define-color success_bg_color @green_4;
+@define-color success_fg_color @light_1;
+@define-color success_color @green_4;
+
+@define-color warning_bg_color @yellow_5;
+@define-color warning_fg_color @light_1;
+@define-color warning_color @yellow_5;
+
+@define-color error_bg_color @red_4;
+@define-color error_fg_color @light_1;
+@define-color error_color @red_4;
+
+// Window
+@define-color window_bg_color #{if($variant == 'light', #fafafa, lighten(#181818, 8%))};
+@define-color window_fg_color #{if($variant=='light', '@dark_3', '@light_2')};
+
+// Views - e.g. text view or tree view
+@define-color view_bg_color #{if($variant == 'light', #ffffff, #1e1e1e)};
+@define-color view_fg_color #{if($variant == 'light', #000000, #ffffff)};
+
+// Header bar, search bar, tab bar
+@define-color headerbar_bg_color #{if($variant == 'light', #ebebeb, #303030)};
+@define-color headerbar_fg_color #{if($variant == 'light', transparentize(black, .2), white)};
+@define-color headerbar_backdrop_color @window_bg_color;
+
+// Cards, boxed lists
+@define-color card_bg_color #{if($variant == 'light', #ffffff, transparentize(white, .92))};
+@define-color card_fg_color #{if($variant == 'light', transparentize(black, .2), white)};
+
+// Popovers
+@define-color popover_bg_color #{if($variant == 'light', #ffffff, #383838)};
+@define-color popover_fg_color #{if($variant == 'light', transparentize(black, .2), white)};

--- a/themes/yaru-prussiangreen-dark/_functions.scss
+++ b/themes/yaru-prussiangreen-dark/_functions.scss
@@ -1,0 +1,16 @@
+@function gtkalpha($c,$a) {
+  @return unquote("alpha(#{$c},#{$a})");
+}
+
+@function gtkmix($c1,$c2,$r) {
+  $ratio: 1 -  $r / 100%; // match SCSS mix()
+  @return unquote("mix(#{$c1},#{$c2},#{$ratio})");
+}
+
+@function gtkshade($c,$s) {
+  @return unquote("shade(#{$c},#{$s})");
+}
+
+@function gtkcolor($c) {
+  @return unquote("@#{$c}");
+}

--- a/themes/yaru-prussiangreen-dark/_palette.scss
+++ b/themes/yaru-prussiangreen-dark/_palette.scss
@@ -1,0 +1,110 @@
+$blue_1: #75d3f4;
+$blue_2: #47c4f1;
+$blue_3: #19B6EE; // Yaru blue
+$blue_4: #007aa6; // Yaru linkblue
+$blue_5: #335280; // Yaru darkblue
+$green_1: #5AED70;
+$green_2: #47D35C;
+$green_3: #34B948;
+$green_4: #219E34;
+$green_5: #0e8420; // Yaru green
+$yellow_1: #FCCD87;
+$yellow_2: #FBC16A;
+$yellow_3: #FBB44C;
+$yellow_4: #FAA82F;
+$yellow_5: #F99B11; // Yaru yellow
+$orange_1: #F29879;
+$orange_2: #F08763;
+$orange_3: #ED764D;
+$orange_4: #EB6536;
+$orange_5: #E95420; // Yaru orange
+$red_1: #EA485C;
+$red_2: #DE374C;
+$red_3: #D3273B;
+$red_4: #c7162b; // Yaru red
+$red_5: #a91224;
+$purple_1: #924D8B; // Yaru aubergine
+$purple_2: #762572; // Yaru purple
+$purple_3: #77216F; // Yaru light aubergine
+$purple_4: #5E2750; // Yaru mid aubergine
+$purple_5: #2C001E; // Yaru dark aubergine
+$brown_1: #E1B289;
+$brown_2: #C5976E;
+$brown_3: #AA7B53;
+$brown_4: #8E6038;
+$brown_5: #72441D;
+$light_1: #FFFFFF;
+$light_2: #F7F7F7; // Yaru porcelain
+$light_3: #CCC; // Yaru silk
+$light_4: #AEA79F; // Yaru warm gray
+$light_5: #878787; // Yaru ash
+$dark_1: #666666; // Yaru graphite
+$dark_2: #5D5D5D; // Yaru slate
+$dark_3: #3D3D3D; // Yaru inkstone
+$dark_4: #181818; // Yaru jet
+$dark_5: #000000;
+
+// Ubuntu accent colors
+$default: $orange_5;
+$bark: #787859;
+$sage: #657B69;
+$olive: #4B8501;
+$viridian: #03875B;
+$prussiangreen: #308280;
+$blue: #0073E5;
+$purple: #7764D8;
+$magenta: #B34CB3;
+$red: #DA3450;
+
+$yaru_accent_bg_color: $prussiangreen !default;
+@define-color yaru_accent_bg_color #{$yaru_accent_bg_color};
+
+
+// Sass thinks we're using the colors in the variables as strings and may shoot
+// warning, it's innocuous and can be defeated by using #{$var}.
+
+@define-color blue_1 #{$blue_1};
+@define-color blue_2 #{$blue_2};
+@define-color blue_3 #{$blue_3};
+@define-color blue_4 #{$blue_4};
+@define-color blue_5 #{$blue_5};
+@define-color green_1 #{$green_1};
+@define-color green_2 #{$green_2};
+@define-color green_3 #{$green_3};
+@define-color green_4 #{$green_4};
+@define-color green_5 #{$green_5};
+@define-color yellow_1 #{$yellow_1};
+@define-color yellow_2 #{$yellow_2};
+@define-color yellow_3 #{$yellow_3};
+@define-color yellow_4 #{$yellow_4};
+@define-color yellow_5 #{$yellow_5};
+@define-color orange_1 #{$orange_1};
+@define-color orange_2 #{$orange_2};
+@define-color orange_3 #{$orange_3};
+@define-color orange_4 #{$orange_4};
+@define-color orange_5 #{$orange_5};
+@define-color red_1 #{$red_1};
+@define-color red_2 #{$red_2};
+@define-color red_3 #{$red_3};
+@define-color red_4 #{$red_4};
+@define-color red_5 #{$red_5};
+@define-color purple_1 #{$purple_1};
+@define-color purple_2 #{$purple_2};
+@define-color purple_3 #{$purple_3};
+@define-color purple_4 #{$purple_4};
+@define-color purple_5 #{$purple_5};
+@define-color brown_1 #{$brown_1};
+@define-color brown_2 #{$brown_2};
+@define-color brown_3 #{$brown_3};
+@define-color brown_4 #{$brown_4};
+@define-color brown_5 #{$brown_5};
+@define-color light_1 #{$light_1};
+@define-color light_2 #{$light_2};
+@define-color light_3 #{$light_3};
+@define-color light_4 #{$light_4};
+@define-color light_5 #{$light_5};
+@define-color dark_1 #{$dark_1};
+@define-color dark_2 #{$dark_2};
+@define-color dark_3 #{$dark_3};
+@define-color dark_4 #{$dark_4};
+@define-color dark_5 #{$dark_5};

--- a/themes/yaru-prussiangreen-dark/_tweaks.scss
+++ b/themes/yaru-prussiangreen-dark/_tweaks.scss
@@ -1,0 +1,73 @@
+// Reducing the amount of the palette's background colors to two
+.sidebar {
+	background-color: $window_bg_color;
+}
+
+// Entries drown if drawn on widgets with $base_color
+// Fixing this at least for notebooks, since entries on tabs is a common pattern
+// Remove this when upstream makes entries have a light border in the dark theme
+@if $variant== "dark" {
+	notebook entry {
+			background-color: gtkmix($view_bg_color, black, 98%);
+	}
+}
+
+// Fix popover wiggling effect (see #2903)
+popover.menu {
+	check,
+	radio {
+			transition: none;
+	}
+}
+
+// Use our own palette for high and not empty levelbar
+levelbar {
+	> trough {
+			> block {
+					&.high,
+					&:not(.empty) {
+							background-color: $success_color;
+					}
+			}
+	}
+}
+
+// Green suggested buttons
+%button,
+button {
+	&.suggested-action {
+			color: $success_fg_color;
+
+			&,
+			&:checked {
+					&:not(.flat) {
+							background-color: $success_bg_color;
+					}
+			}
+	}
+
+	&.flat {
+			&.suggested-action {
+					color: $success_color;
+			}
+	}
+}
+
+splitbutton {
+	&.suggested-action {
+			> button, > menubutton > button {
+					color: $success_fg_color;
+	
+					&, &:checked {
+							background-color: $success_bg_color;
+					}
+			}
+	}
+}
+
+%button,
+button,
+%link,
+link {
+	font-weight: normal;
+}

--- a/themes/yaru-prussiangreen-dark/gtk-dark.scss
+++ b/themes/yaru-prussiangreen-dark/gtk-dark.scss
@@ -1,0 +1,13 @@
+// General guidelines:
+// - very unlikely you want to edit something else than _common.scss
+// - keep the number of defined colors to a minimum, use the color blending functions if
+//   you need a subtle shade
+// - if you need to inverse a color function use the @if directive to match for dark $variant
+
+$variant: 'dark';
+
+@import 'palette';
+@import 'defaults';
+@import 'functions';
+@import 'colors';
+@import 'tweaks';

--- a/themes/yaru-prussiangreen-dark/gtk.css
+++ b/themes/yaru-prussiangreen-dark/gtk.css
@@ -1,0 +1,121 @@
+@define-color yaru_accent_bg_color #308280;
+@define-color blue_1 #75d3f4;
+@define-color blue_2 #47c4f1;
+@define-color blue_3 #19B6EE;
+@define-color blue_4 #007aa6;
+@define-color blue_5 #335280;
+@define-color green_1 #5AED70;
+@define-color green_2 #47D35C;
+@define-color green_3 #34B948;
+@define-color green_4 #219E34;
+@define-color green_5 #0e8420;
+@define-color yellow_1 #FCCD87;
+@define-color yellow_2 #FBC16A;
+@define-color yellow_3 #FBB44C;
+@define-color yellow_4 #FAA82F;
+@define-color yellow_5 #F99B11;
+@define-color orange_1 #F29879;
+@define-color orange_2 #F08763;
+@define-color orange_3 #ED764D;
+@define-color orange_4 #EB6536;
+@define-color orange_5 #E95420;
+@define-color red_1 #EA485C;
+@define-color red_2 #DE374C;
+@define-color red_3 #D3273B;
+@define-color red_4 #c7162b;
+@define-color red_5 #a91224;
+@define-color purple_1 #924D8B;
+@define-color purple_2 #762572;
+@define-color purple_3 #77216F;
+@define-color purple_4 #5E2750;
+@define-color purple_5 #2C001E;
+@define-color brown_1 #E1B289;
+@define-color brown_2 #C5976E;
+@define-color brown_3 #AA7B53;
+@define-color brown_4 #8E6038;
+@define-color brown_5 #72441D;
+@define-color light_1 #FFFFFF;
+@define-color light_2 #F7F7F7;
+@define-color light_3 #CCC;
+@define-color light_4 #AEA79F;
+@define-color light_5 #878787;
+@define-color dark_1 #666666;
+@define-color dark_2 #5D5D5D;
+@define-color dark_3 #3D3D3D;
+@define-color dark_4 #181818;
+@define-color dark_5 #000000;
+/* GTK NAMED COLORS
+   ----------------
+   use responsibly! */
+@define-color accent_bg_color @yaru_accent_bg_color;
+@define-color accent_fg_color @light_1;
+@define-color accent_color @yaru_accent_bg_color;
+@define-color destructive_bg_color @red_4;
+@define-color destructive_fg_color @light_1;
+@define-color destructive_color @red_4;
+@define-color success_bg_color @green_4;
+@define-color success_fg_color @light_1;
+@define-color success_color @green_4;
+@define-color warning_bg_color @yellow_5;
+@define-color warning_fg_color @light_1;
+@define-color warning_color @yellow_5;
+@define-color error_bg_color @red_4;
+@define-color error_fg_color @light_1;
+@define-color error_color @red_4;
+@define-color window_bg_color #2c2c2c;
+@define-color window_fg_color @light_2;
+@define-color view_bg_color #1e1e1e;
+@define-color view_fg_color #ffffff;
+@define-color headerbar_bg_color #303030;
+@define-color headerbar_fg_color white;
+@define-color headerbar_backdrop_color @window_bg_color;
+@define-color card_bg_color rgba(255, 255, 255, 0.08);
+@define-color card_fg_color white;
+@define-color popover_bg_color #383838;
+@define-color popover_fg_color white;
+.sidebar {
+  background-color: @window_bg_color;
+}
+
+notebook entry {
+  background-color: mix(@view_bg_color,black,0.02);
+}
+
+popover.menu check,
+popover.menu radio {
+  transition: none;
+}
+
+levelbar > trough > block.high, levelbar > trough > block:not(.empty) {
+  background-color: @success_color;
+}
+
+
+button.suggested-action {
+  color: @success_fg_color;
+}
+
+
+button.suggested-action:not(.flat),
+button.suggested-action:checked:not(.flat) {
+  background-color: @success_bg_color;
+}
+
+
+button.flat.suggested-action {
+  color: @success_color;
+}
+
+splitbutton.suggested-action > button, splitbutton.suggested-action > menubutton > button {
+  color: @success_fg_color;
+}
+
+splitbutton.suggested-action > button, splitbutton.suggested-action > button:checked, splitbutton.suggested-action > menubutton > button, splitbutton.suggested-action > menubutton > button:checked {
+  background-color: @success_bg_color;
+}
+
+
+button,
+link {
+  font-weight: normal;
+}

--- a/themes/yaru-prussiangreen-dark/gtk.scss
+++ b/themes/yaru-prussiangreen-dark/gtk.scss
@@ -1,0 +1,14 @@
+// General guidelines:
+// - very unlikely you want to edit something else than _common.scss
+// - keep the number of defined colors to a minimum, use the color blending functions if
+//   you need a subtle shade
+// - if you need to inverse a color function use the @if directive to match for dark $variant
+
+$variant: 'light';
+
+@import 'palette';
+@import 'defaults';
+@import 'functions';
+@import 'colors';
+@import 'tweaks';
+

--- a/themes/yaru-prussiangreen-dark/parse-sass.sh
+++ b/themes/yaru-prussiangreen-dark/parse-sass.sh
@@ -1,0 +1,12 @@
+#! /bin/bash
+
+if [ ! "$(which sassc 2> /dev/null)" ]; then
+   echo sassc needs to be installed to generate the css.
+   exit 1
+fi
+
+SASSC_OPT="-M -t expanded"
+
+echo Generating the css...
+
+sassc $SASSC_OPT gtk-dark.scss gtk.css

--- a/themes/yaru-prussiangreen/_colors.scss
+++ b/themes/yaru-prussiangreen/_colors.scss
@@ -1,0 +1,35 @@
+$accent_bg_color: gtkcolor(accent_bg_color);
+$accent_fg_color: gtkcolor(accent_fg_color);
+$accent_color: gtkcolor(accent_color);
+
+$destructive_bg_color: gtkcolor(destructive_bg_color);
+$destructive_fg_color: gtkcolor(destructive_fg_color);
+$destructive_color: gtkcolor(destructive_color);
+
+$success_bg_color: gtkcolor(success_bg_color);
+$success_fg_color: gtkcolor(success_fg_color);
+$success_color: gtkcolor(success_color);
+
+$warning_bg_color: gtkcolor(warning_bg_color);
+$warning_fg_color: gtkcolor(warning_fg_color);
+$warning_color: gtkcolor(warning_color);
+
+$error_bg_color: gtkcolor(error_bg_color);
+$error_fg_color: gtkcolor(error_fg_color);
+$error_color: gtkcolor(error_color);
+
+$window_bg_color: gtkcolor(window_bg_color);
+$window_fg_color: gtkcolor(window_fg_color);
+
+$view_bg_color: gtkcolor(view_bg_color);
+$view_fg_color: gtkcolor(view_fg_color);
+
+$headerbar_bg_color: gtkcolor(headerbar_bg_color);
+$headerbar_fg_color: gtkcolor(headerbar_fg_color);
+$headerbar_backdrop_color: gtkcolor(headerbar_backdrop_color);
+
+$card_bg_color: gtkcolor(card_bg_color);
+$card_fg_color: gtkcolor(card_fg_color);
+
+$popover_bg_color: gtkcolor(popover_bg_color);
+$popover_fg_color: gtkcolor(popover_fg_color);

--- a/themes/yaru-prussiangreen/_defaults.scss
+++ b/themes/yaru-prussiangreen/_defaults.scss
@@ -1,0 +1,53 @@
+/* GTK NAMED COLORS
+   ----------------
+   use responsibly! */
+
+// Sass thinks we're using the colors in the variables as strings and may shoot
+// warning, it's innocuous and can be defeated by using #{$var}.
+
+// These are the colors apps are can override. We define the defaults here and
+// define variables for them in _colors.scss
+
+// The main accent color and the matching text value
+@define-color accent_bg_color @yaru_accent_bg_color;
+@define-color accent_fg_color @light_1;
+@define-color accent_color @yaru_accent_bg_color;
+
+// destructive-action buttons
+@define-color destructive_bg_color @red_4;
+@define-color destructive_fg_color @light_1;
+@define-color destructive_color @red_4;
+
+// Levelbars, entries, labels and infobars. These don't need text colors
+@define-color success_bg_color @green_4;
+@define-color success_fg_color @light_1;
+@define-color success_color @green_4;
+
+@define-color warning_bg_color @yellow_5;
+@define-color warning_fg_color @light_1;
+@define-color warning_color @yellow_5;
+
+@define-color error_bg_color @red_4;
+@define-color error_fg_color @light_1;
+@define-color error_color @red_4;
+
+// Window
+@define-color window_bg_color #{if($variant == 'light', #fafafa, lighten(#181818, 8%))};
+@define-color window_fg_color #{if($variant=='light', '@dark_3', '@light_2')};
+
+// Views - e.g. text view or tree view
+@define-color view_bg_color #{if($variant == 'light', #ffffff, #1e1e1e)};
+@define-color view_fg_color #{if($variant == 'light', #000000, #ffffff)};
+
+// Header bar, search bar, tab bar
+@define-color headerbar_bg_color #{if($variant == 'light', #ebebeb, #303030)};
+@define-color headerbar_fg_color #{if($variant == 'light', transparentize(black, .2), white)};
+@define-color headerbar_backdrop_color @window_bg_color;
+
+// Cards, boxed lists
+@define-color card_bg_color #{if($variant == 'light', #ffffff, transparentize(white, .92))};
+@define-color card_fg_color #{if($variant == 'light', transparentize(black, .2), white)};
+
+// Popovers
+@define-color popover_bg_color #{if($variant == 'light', #ffffff, #383838)};
+@define-color popover_fg_color #{if($variant == 'light', transparentize(black, .2), white)};

--- a/themes/yaru-prussiangreen/_functions.scss
+++ b/themes/yaru-prussiangreen/_functions.scss
@@ -1,0 +1,16 @@
+@function gtkalpha($c,$a) {
+  @return unquote("alpha(#{$c},#{$a})");
+}
+
+@function gtkmix($c1,$c2,$r) {
+  $ratio: 1 -  $r / 100%; // match SCSS mix()
+  @return unquote("mix(#{$c1},#{$c2},#{$ratio})");
+}
+
+@function gtkshade($c,$s) {
+  @return unquote("shade(#{$c},#{$s})");
+}
+
+@function gtkcolor($c) {
+  @return unquote("@#{$c}");
+}

--- a/themes/yaru-prussiangreen/_palette.scss
+++ b/themes/yaru-prussiangreen/_palette.scss
@@ -1,0 +1,110 @@
+$blue_1: #75d3f4;
+$blue_2: #47c4f1;
+$blue_3: #19B6EE; // Yaru blue
+$blue_4: #007aa6; // Yaru linkblue
+$blue_5: #335280; // Yaru darkblue
+$green_1: #5AED70;
+$green_2: #47D35C;
+$green_3: #34B948;
+$green_4: #219E34;
+$green_5: #0e8420; // Yaru green
+$yellow_1: #FCCD87;
+$yellow_2: #FBC16A;
+$yellow_3: #FBB44C;
+$yellow_4: #FAA82F;
+$yellow_5: #F99B11; // Yaru yellow
+$orange_1: #F29879;
+$orange_2: #F08763;
+$orange_3: #ED764D;
+$orange_4: #EB6536;
+$orange_5: #E95420; // Yaru orange
+$red_1: #EA485C;
+$red_2: #DE374C;
+$red_3: #D3273B;
+$red_4: #c7162b; // Yaru red
+$red_5: #a91224;
+$purple_1: #924D8B; // Yaru aubergine
+$purple_2: #762572; // Yaru purple
+$purple_3: #77216F; // Yaru light aubergine
+$purple_4: #5E2750; // Yaru mid aubergine
+$purple_5: #2C001E; // Yaru dark aubergine
+$brown_1: #E1B289;
+$brown_2: #C5976E;
+$brown_3: #AA7B53;
+$brown_4: #8E6038;
+$brown_5: #72441D;
+$light_1: #FFFFFF;
+$light_2: #F7F7F7; // Yaru porcelain
+$light_3: #CCC; // Yaru silk
+$light_4: #AEA79F; // Yaru warm gray
+$light_5: #878787; // Yaru ash
+$dark_1: #666666; // Yaru graphite
+$dark_2: #5D5D5D; // Yaru slate
+$dark_3: #3D3D3D; // Yaru inkstone
+$dark_4: #181818; // Yaru jet
+$dark_5: #000000;
+
+// Ubuntu accent colors
+$default: $orange_5;
+$bark: #787859;
+$sage: #657B69;
+$olive: #4B8501;
+$viridian: #03875B;
+$prussiangreen: #308280;
+$blue: #0073E5;
+$purple: #7764D8;
+$magenta: #B34CB3;
+$red: #DA3450;
+
+$yaru_accent_bg_color: $prussiangreen !default;
+@define-color yaru_accent_bg_color #{$yaru_accent_bg_color};
+
+
+// Sass thinks we're using the colors in the variables as strings and may shoot
+// warning, it's innocuous and can be defeated by using #{$var}.
+
+@define-color blue_1 #{$blue_1};
+@define-color blue_2 #{$blue_2};
+@define-color blue_3 #{$blue_3};
+@define-color blue_4 #{$blue_4};
+@define-color blue_5 #{$blue_5};
+@define-color green_1 #{$green_1};
+@define-color green_2 #{$green_2};
+@define-color green_3 #{$green_3};
+@define-color green_4 #{$green_4};
+@define-color green_5 #{$green_5};
+@define-color yellow_1 #{$yellow_1};
+@define-color yellow_2 #{$yellow_2};
+@define-color yellow_3 #{$yellow_3};
+@define-color yellow_4 #{$yellow_4};
+@define-color yellow_5 #{$yellow_5};
+@define-color orange_1 #{$orange_1};
+@define-color orange_2 #{$orange_2};
+@define-color orange_3 #{$orange_3};
+@define-color orange_4 #{$orange_4};
+@define-color orange_5 #{$orange_5};
+@define-color red_1 #{$red_1};
+@define-color red_2 #{$red_2};
+@define-color red_3 #{$red_3};
+@define-color red_4 #{$red_4};
+@define-color red_5 #{$red_5};
+@define-color purple_1 #{$purple_1};
+@define-color purple_2 #{$purple_2};
+@define-color purple_3 #{$purple_3};
+@define-color purple_4 #{$purple_4};
+@define-color purple_5 #{$purple_5};
+@define-color brown_1 #{$brown_1};
+@define-color brown_2 #{$brown_2};
+@define-color brown_3 #{$brown_3};
+@define-color brown_4 #{$brown_4};
+@define-color brown_5 #{$brown_5};
+@define-color light_1 #{$light_1};
+@define-color light_2 #{$light_2};
+@define-color light_3 #{$light_3};
+@define-color light_4 #{$light_4};
+@define-color light_5 #{$light_5};
+@define-color dark_1 #{$dark_1};
+@define-color dark_2 #{$dark_2};
+@define-color dark_3 #{$dark_3};
+@define-color dark_4 #{$dark_4};
+@define-color dark_5 #{$dark_5};

--- a/themes/yaru-prussiangreen/_tweaks.scss
+++ b/themes/yaru-prussiangreen/_tweaks.scss
@@ -1,0 +1,73 @@
+// Reducing the amount of the palette's background colors to two
+.sidebar {
+	background-color: $window_bg_color;
+}
+
+// Entries drown if drawn on widgets with $base_color
+// Fixing this at least for notebooks, since entries on tabs is a common pattern
+// Remove this when upstream makes entries have a light border in the dark theme
+@if $variant== "dark" {
+	notebook entry {
+			background-color: gtkmix($view_bg_color, black, 98%);
+	}
+}
+
+// Fix popover wiggling effect (see #2903)
+popover.menu {
+	check,
+	radio {
+			transition: none;
+	}
+}
+
+// Use our own palette for high and not empty levelbar
+levelbar {
+	> trough {
+			> block {
+					&.high,
+					&:not(.empty) {
+							background-color: $success_color;
+					}
+			}
+	}
+}
+
+// Green suggested buttons
+%button,
+button {
+	&.suggested-action {
+			color: $success_fg_color;
+
+			&,
+			&:checked {
+					&:not(.flat) {
+							background-color: $success_bg_color;
+					}
+			}
+	}
+
+	&.flat {
+			&.suggested-action {
+					color: $success_color;
+			}
+	}
+}
+
+splitbutton {
+	&.suggested-action {
+			> button, > menubutton > button {
+					color: $success_fg_color;
+	
+					&, &:checked {
+							background-color: $success_bg_color;
+					}
+			}
+	}
+}
+
+%button,
+button,
+%link,
+link {
+	font-weight: normal;
+}

--- a/themes/yaru-prussiangreen/gtk-dark.scss
+++ b/themes/yaru-prussiangreen/gtk-dark.scss
@@ -1,0 +1,13 @@
+// General guidelines:
+// - very unlikely you want to edit something else than _common.scss
+// - keep the number of defined colors to a minimum, use the color blending functions if
+//   you need a subtle shade
+// - if you need to inverse a color function use the @if directive to match for dark $variant
+
+$variant: 'dark';
+
+@import 'palette';
+@import 'defaults';
+@import 'functions';
+@import 'colors';
+@import 'tweaks';

--- a/themes/yaru-prussiangreen/gtk.css
+++ b/themes/yaru-prussiangreen/gtk.css
@@ -1,0 +1,117 @@
+@define-color yaru_accent_bg_color #308280;
+@define-color blue_1 #75d3f4;
+@define-color blue_2 #47c4f1;
+@define-color blue_3 #19B6EE;
+@define-color blue_4 #007aa6;
+@define-color blue_5 #335280;
+@define-color green_1 #5AED70;
+@define-color green_2 #47D35C;
+@define-color green_3 #34B948;
+@define-color green_4 #219E34;
+@define-color green_5 #0e8420;
+@define-color yellow_1 #FCCD87;
+@define-color yellow_2 #FBC16A;
+@define-color yellow_3 #FBB44C;
+@define-color yellow_4 #FAA82F;
+@define-color yellow_5 #F99B11;
+@define-color orange_1 #F29879;
+@define-color orange_2 #F08763;
+@define-color orange_3 #ED764D;
+@define-color orange_4 #EB6536;
+@define-color orange_5 #E95420;
+@define-color red_1 #EA485C;
+@define-color red_2 #DE374C;
+@define-color red_3 #D3273B;
+@define-color red_4 #c7162b;
+@define-color red_5 #a91224;
+@define-color purple_1 #924D8B;
+@define-color purple_2 #762572;
+@define-color purple_3 #77216F;
+@define-color purple_4 #5E2750;
+@define-color purple_5 #2C001E;
+@define-color brown_1 #E1B289;
+@define-color brown_2 #C5976E;
+@define-color brown_3 #AA7B53;
+@define-color brown_4 #8E6038;
+@define-color brown_5 #72441D;
+@define-color light_1 #FFFFFF;
+@define-color light_2 #F7F7F7;
+@define-color light_3 #CCC;
+@define-color light_4 #AEA79F;
+@define-color light_5 #878787;
+@define-color dark_1 #666666;
+@define-color dark_2 #5D5D5D;
+@define-color dark_3 #3D3D3D;
+@define-color dark_4 #181818;
+@define-color dark_5 #000000;
+/* GTK NAMED COLORS
+   ----------------
+   use responsibly! */
+@define-color accent_bg_color @yaru_accent_bg_color;
+@define-color accent_fg_color @light_1;
+@define-color accent_color @yaru_accent_bg_color;
+@define-color destructive_bg_color @red_4;
+@define-color destructive_fg_color @light_1;
+@define-color destructive_color @red_4;
+@define-color success_bg_color @green_4;
+@define-color success_fg_color @light_1;
+@define-color success_color @green_4;
+@define-color warning_bg_color @yellow_5;
+@define-color warning_fg_color @light_1;
+@define-color warning_color @yellow_5;
+@define-color error_bg_color @red_4;
+@define-color error_fg_color @light_1;
+@define-color error_color @red_4;
+@define-color window_bg_color #fafafa;
+@define-color window_fg_color @dark_3;
+@define-color view_bg_color #ffffff;
+@define-color view_fg_color #000000;
+@define-color headerbar_bg_color #ebebeb;
+@define-color headerbar_fg_color rgba(0, 0, 0, 0.8);
+@define-color headerbar_backdrop_color @window_bg_color;
+@define-color card_bg_color #ffffff;
+@define-color card_fg_color rgba(0, 0, 0, 0.8);
+@define-color popover_bg_color #ffffff;
+@define-color popover_fg_color rgba(0, 0, 0, 0.8);
+.sidebar {
+  background-color: @window_bg_color;
+}
+
+popover.menu check,
+popover.menu radio {
+  transition: none;
+}
+
+levelbar > trough > block.high, levelbar > trough > block:not(.empty) {
+  background-color: @success_color;
+}
+
+
+button.suggested-action {
+  color: @success_fg_color;
+}
+
+
+button.suggested-action:not(.flat),
+button.suggested-action:checked:not(.flat) {
+  background-color: @success_bg_color;
+}
+
+
+button.flat.suggested-action {
+  color: @success_color;
+}
+
+splitbutton.suggested-action > button, splitbutton.suggested-action > menubutton > button {
+  color: @success_fg_color;
+}
+
+splitbutton.suggested-action > button, splitbutton.suggested-action > button:checked, splitbutton.suggested-action > menubutton > button, splitbutton.suggested-action > menubutton > button:checked {
+  background-color: @success_bg_color;
+}
+
+
+button,
+link {
+  font-weight: normal;
+}

--- a/themes/yaru-prussiangreen/gtk.scss
+++ b/themes/yaru-prussiangreen/gtk.scss
@@ -1,0 +1,14 @@
+// General guidelines:
+// - very unlikely you want to edit something else than _common.scss
+// - keep the number of defined colors to a minimum, use the color blending functions if
+//   you need a subtle shade
+// - if you need to inverse a color function use the @if directive to match for dark $variant
+
+$variant: 'light';
+
+@import 'palette';
+@import 'defaults';
+@import 'functions';
+@import 'colors';
+@import 'tweaks';
+

--- a/themes/yaru-prussiangreen/parse-sass.sh
+++ b/themes/yaru-prussiangreen/parse-sass.sh
@@ -1,0 +1,12 @@
+#! /bin/bash
+
+if [ ! "$(which sassc 2> /dev/null)" ]; then
+   echo sassc needs to be installed to generate the css.
+   exit 1
+fi
+
+SASSC_OPT="-M -t expanded"
+
+echo Generating the css...
+
+sassc $SASSC_OPT gtk.scss gtk.css

--- a/themes/yaru-purple-dark/_colors.scss
+++ b/themes/yaru-purple-dark/_colors.scss
@@ -1,0 +1,35 @@
+$accent_bg_color: gtkcolor(accent_bg_color);
+$accent_fg_color: gtkcolor(accent_fg_color);
+$accent_color: gtkcolor(accent_color);
+
+$destructive_bg_color: gtkcolor(destructive_bg_color);
+$destructive_fg_color: gtkcolor(destructive_fg_color);
+$destructive_color: gtkcolor(destructive_color);
+
+$success_bg_color: gtkcolor(success_bg_color);
+$success_fg_color: gtkcolor(success_fg_color);
+$success_color: gtkcolor(success_color);
+
+$warning_bg_color: gtkcolor(warning_bg_color);
+$warning_fg_color: gtkcolor(warning_fg_color);
+$warning_color: gtkcolor(warning_color);
+
+$error_bg_color: gtkcolor(error_bg_color);
+$error_fg_color: gtkcolor(error_fg_color);
+$error_color: gtkcolor(error_color);
+
+$window_bg_color: gtkcolor(window_bg_color);
+$window_fg_color: gtkcolor(window_fg_color);
+
+$view_bg_color: gtkcolor(view_bg_color);
+$view_fg_color: gtkcolor(view_fg_color);
+
+$headerbar_bg_color: gtkcolor(headerbar_bg_color);
+$headerbar_fg_color: gtkcolor(headerbar_fg_color);
+$headerbar_backdrop_color: gtkcolor(headerbar_backdrop_color);
+
+$card_bg_color: gtkcolor(card_bg_color);
+$card_fg_color: gtkcolor(card_fg_color);
+
+$popover_bg_color: gtkcolor(popover_bg_color);
+$popover_fg_color: gtkcolor(popover_fg_color);

--- a/themes/yaru-purple-dark/_defaults.scss
+++ b/themes/yaru-purple-dark/_defaults.scss
@@ -1,0 +1,53 @@
+/* GTK NAMED COLORS
+   ----------------
+   use responsibly! */
+
+// Sass thinks we're using the colors in the variables as strings and may shoot
+// warning, it's innocuous and can be defeated by using #{$var}.
+
+// These are the colors apps are can override. We define the defaults here and
+// define variables for them in _colors.scss
+
+// The main accent color and the matching text value
+@define-color accent_bg_color @yaru_accent_bg_color;
+@define-color accent_fg_color @light_1;
+@define-color accent_color @yaru_accent_bg_color;
+
+// destructive-action buttons
+@define-color destructive_bg_color @red_4;
+@define-color destructive_fg_color @light_1;
+@define-color destructive_color @red_4;
+
+// Levelbars, entries, labels and infobars. These don't need text colors
+@define-color success_bg_color @green_4;
+@define-color success_fg_color @light_1;
+@define-color success_color @green_4;
+
+@define-color warning_bg_color @yellow_5;
+@define-color warning_fg_color @light_1;
+@define-color warning_color @yellow_5;
+
+@define-color error_bg_color @red_4;
+@define-color error_fg_color @light_1;
+@define-color error_color @red_4;
+
+// Window
+@define-color window_bg_color #{if($variant == 'light', #fafafa, lighten(#181818, 8%))};
+@define-color window_fg_color #{if($variant=='light', '@dark_3', '@light_2')};
+
+// Views - e.g. text view or tree view
+@define-color view_bg_color #{if($variant == 'light', #ffffff, #1e1e1e)};
+@define-color view_fg_color #{if($variant == 'light', #000000, #ffffff)};
+
+// Header bar, search bar, tab bar
+@define-color headerbar_bg_color #{if($variant == 'light', #ebebeb, #303030)};
+@define-color headerbar_fg_color #{if($variant == 'light', transparentize(black, .2), white)};
+@define-color headerbar_backdrop_color @window_bg_color;
+
+// Cards, boxed lists
+@define-color card_bg_color #{if($variant == 'light', #ffffff, transparentize(white, .92))};
+@define-color card_fg_color #{if($variant == 'light', transparentize(black, .2), white)};
+
+// Popovers
+@define-color popover_bg_color #{if($variant == 'light', #ffffff, #383838)};
+@define-color popover_fg_color #{if($variant == 'light', transparentize(black, .2), white)};

--- a/themes/yaru-purple-dark/_functions.scss
+++ b/themes/yaru-purple-dark/_functions.scss
@@ -1,0 +1,16 @@
+@function gtkalpha($c,$a) {
+  @return unquote("alpha(#{$c},#{$a})");
+}
+
+@function gtkmix($c1,$c2,$r) {
+  $ratio: 1 -  $r / 100%; // match SCSS mix()
+  @return unquote("mix(#{$c1},#{$c2},#{$ratio})");
+}
+
+@function gtkshade($c,$s) {
+  @return unquote("shade(#{$c},#{$s})");
+}
+
+@function gtkcolor($c) {
+  @return unquote("@#{$c}");
+}

--- a/themes/yaru-purple-dark/_palette.scss
+++ b/themes/yaru-purple-dark/_palette.scss
@@ -1,0 +1,110 @@
+$blue_1: #75d3f4;
+$blue_2: #47c4f1;
+$blue_3: #19B6EE; // Yaru blue
+$blue_4: #007aa6; // Yaru linkblue
+$blue_5: #335280; // Yaru darkblue
+$green_1: #5AED70;
+$green_2: #47D35C;
+$green_3: #34B948;
+$green_4: #219E34;
+$green_5: #0e8420; // Yaru green
+$yellow_1: #FCCD87;
+$yellow_2: #FBC16A;
+$yellow_3: #FBB44C;
+$yellow_4: #FAA82F;
+$yellow_5: #F99B11; // Yaru yellow
+$orange_1: #F29879;
+$orange_2: #F08763;
+$orange_3: #ED764D;
+$orange_4: #EB6536;
+$orange_5: #E95420; // Yaru orange
+$red_1: #EA485C;
+$red_2: #DE374C;
+$red_3: #D3273B;
+$red_4: #c7162b; // Yaru red
+$red_5: #a91224;
+$purple_1: #924D8B; // Yaru aubergine
+$purple_2: #762572; // Yaru purple
+$purple_3: #77216F; // Yaru light aubergine
+$purple_4: #5E2750; // Yaru mid aubergine
+$purple_5: #2C001E; // Yaru dark aubergine
+$brown_1: #E1B289;
+$brown_2: #C5976E;
+$brown_3: #AA7B53;
+$brown_4: #8E6038;
+$brown_5: #72441D;
+$light_1: #FFFFFF;
+$light_2: #F7F7F7; // Yaru porcelain
+$light_3: #CCC; // Yaru silk
+$light_4: #AEA79F; // Yaru warm gray
+$light_5: #878787; // Yaru ash
+$dark_1: #666666; // Yaru graphite
+$dark_2: #5D5D5D; // Yaru slate
+$dark_3: #3D3D3D; // Yaru inkstone
+$dark_4: #181818; // Yaru jet
+$dark_5: #000000;
+
+// Ubuntu accent colors
+$default: $orange_5;
+$bark: #787859;
+$sage: #657B69;
+$olive: #4B8501;
+$viridian: #03875B;
+$prussiangreen: #308280;
+$blue: #0073E5;
+$purple: #7764D8;
+$magenta: #B34CB3;
+$red: #DA3450;
+
+$yaru_accent_bg_color: $purple !default;
+@define-color yaru_accent_bg_color #{$yaru_accent_bg_color};
+
+
+// Sass thinks we're using the colors in the variables as strings and may shoot
+// warning, it's innocuous and can be defeated by using #{$var}.
+
+@define-color blue_1 #{$blue_1};
+@define-color blue_2 #{$blue_2};
+@define-color blue_3 #{$blue_3};
+@define-color blue_4 #{$blue_4};
+@define-color blue_5 #{$blue_5};
+@define-color green_1 #{$green_1};
+@define-color green_2 #{$green_2};
+@define-color green_3 #{$green_3};
+@define-color green_4 #{$green_4};
+@define-color green_5 #{$green_5};
+@define-color yellow_1 #{$yellow_1};
+@define-color yellow_2 #{$yellow_2};
+@define-color yellow_3 #{$yellow_3};
+@define-color yellow_4 #{$yellow_4};
+@define-color yellow_5 #{$yellow_5};
+@define-color orange_1 #{$orange_1};
+@define-color orange_2 #{$orange_2};
+@define-color orange_3 #{$orange_3};
+@define-color orange_4 #{$orange_4};
+@define-color orange_5 #{$orange_5};
+@define-color red_1 #{$red_1};
+@define-color red_2 #{$red_2};
+@define-color red_3 #{$red_3};
+@define-color red_4 #{$red_4};
+@define-color red_5 #{$red_5};
+@define-color purple_1 #{$purple_1};
+@define-color purple_2 #{$purple_2};
+@define-color purple_3 #{$purple_3};
+@define-color purple_4 #{$purple_4};
+@define-color purple_5 #{$purple_5};
+@define-color brown_1 #{$brown_1};
+@define-color brown_2 #{$brown_2};
+@define-color brown_3 #{$brown_3};
+@define-color brown_4 #{$brown_4};
+@define-color brown_5 #{$brown_5};
+@define-color light_1 #{$light_1};
+@define-color light_2 #{$light_2};
+@define-color light_3 #{$light_3};
+@define-color light_4 #{$light_4};
+@define-color light_5 #{$light_5};
+@define-color dark_1 #{$dark_1};
+@define-color dark_2 #{$dark_2};
+@define-color dark_3 #{$dark_3};
+@define-color dark_4 #{$dark_4};
+@define-color dark_5 #{$dark_5};

--- a/themes/yaru-purple-dark/_tweaks.scss
+++ b/themes/yaru-purple-dark/_tweaks.scss
@@ -1,0 +1,73 @@
+// Reducing the amount of the palette's background colors to two
+.sidebar {
+	background-color: $window_bg_color;
+}
+
+// Entries drown if drawn on widgets with $base_color
+// Fixing this at least for notebooks, since entries on tabs is a common pattern
+// Remove this when upstream makes entries have a light border in the dark theme
+@if $variant== "dark" {
+	notebook entry {
+			background-color: gtkmix($view_bg_color, black, 98%);
+	}
+}
+
+// Fix popover wiggling effect (see #2903)
+popover.menu {
+	check,
+	radio {
+			transition: none;
+	}
+}
+
+// Use our own palette for high and not empty levelbar
+levelbar {
+	> trough {
+			> block {
+					&.high,
+					&:not(.empty) {
+							background-color: $success_color;
+					}
+			}
+	}
+}
+
+// Green suggested buttons
+%button,
+button {
+	&.suggested-action {
+			color: $success_fg_color;
+
+			&,
+			&:checked {
+					&:not(.flat) {
+							background-color: $success_bg_color;
+					}
+			}
+	}
+
+	&.flat {
+			&.suggested-action {
+					color: $success_color;
+			}
+	}
+}
+
+splitbutton {
+	&.suggested-action {
+			> button, > menubutton > button {
+					color: $success_fg_color;
+	
+					&, &:checked {
+							background-color: $success_bg_color;
+					}
+			}
+	}
+}
+
+%button,
+button,
+%link,
+link {
+	font-weight: normal;
+}

--- a/themes/yaru-purple-dark/gtk-dark.scss
+++ b/themes/yaru-purple-dark/gtk-dark.scss
@@ -1,0 +1,13 @@
+// General guidelines:
+// - very unlikely you want to edit something else than _common.scss
+// - keep the number of defined colors to a minimum, use the color blending functions if
+//   you need a subtle shade
+// - if you need to inverse a color function use the @if directive to match for dark $variant
+
+$variant: 'dark';
+
+@import 'palette';
+@import 'defaults';
+@import 'functions';
+@import 'colors';
+@import 'tweaks';

--- a/themes/yaru-purple-dark/gtk.css
+++ b/themes/yaru-purple-dark/gtk.css
@@ -1,0 +1,121 @@
+@define-color yaru_accent_bg_color #7764D8;
+@define-color blue_1 #75d3f4;
+@define-color blue_2 #47c4f1;
+@define-color blue_3 #19B6EE;
+@define-color blue_4 #007aa6;
+@define-color blue_5 #335280;
+@define-color green_1 #5AED70;
+@define-color green_2 #47D35C;
+@define-color green_3 #34B948;
+@define-color green_4 #219E34;
+@define-color green_5 #0e8420;
+@define-color yellow_1 #FCCD87;
+@define-color yellow_2 #FBC16A;
+@define-color yellow_3 #FBB44C;
+@define-color yellow_4 #FAA82F;
+@define-color yellow_5 #F99B11;
+@define-color orange_1 #F29879;
+@define-color orange_2 #F08763;
+@define-color orange_3 #ED764D;
+@define-color orange_4 #EB6536;
+@define-color orange_5 #E95420;
+@define-color red_1 #EA485C;
+@define-color red_2 #DE374C;
+@define-color red_3 #D3273B;
+@define-color red_4 #c7162b;
+@define-color red_5 #a91224;
+@define-color purple_1 #924D8B;
+@define-color purple_2 #762572;
+@define-color purple_3 #77216F;
+@define-color purple_4 #5E2750;
+@define-color purple_5 #2C001E;
+@define-color brown_1 #E1B289;
+@define-color brown_2 #C5976E;
+@define-color brown_3 #AA7B53;
+@define-color brown_4 #8E6038;
+@define-color brown_5 #72441D;
+@define-color light_1 #FFFFFF;
+@define-color light_2 #F7F7F7;
+@define-color light_3 #CCC;
+@define-color light_4 #AEA79F;
+@define-color light_5 #878787;
+@define-color dark_1 #666666;
+@define-color dark_2 #5D5D5D;
+@define-color dark_3 #3D3D3D;
+@define-color dark_4 #181818;
+@define-color dark_5 #000000;
+/* GTK NAMED COLORS
+   ----------------
+   use responsibly! */
+@define-color accent_bg_color @yaru_accent_bg_color;
+@define-color accent_fg_color @light_1;
+@define-color accent_color @yaru_accent_bg_color;
+@define-color destructive_bg_color @red_4;
+@define-color destructive_fg_color @light_1;
+@define-color destructive_color @red_4;
+@define-color success_bg_color @green_4;
+@define-color success_fg_color @light_1;
+@define-color success_color @green_4;
+@define-color warning_bg_color @yellow_5;
+@define-color warning_fg_color @light_1;
+@define-color warning_color @yellow_5;
+@define-color error_bg_color @red_4;
+@define-color error_fg_color @light_1;
+@define-color error_color @red_4;
+@define-color window_bg_color #2c2c2c;
+@define-color window_fg_color @light_2;
+@define-color view_bg_color #1e1e1e;
+@define-color view_fg_color #ffffff;
+@define-color headerbar_bg_color #303030;
+@define-color headerbar_fg_color white;
+@define-color headerbar_backdrop_color @window_bg_color;
+@define-color card_bg_color rgba(255, 255, 255, 0.08);
+@define-color card_fg_color white;
+@define-color popover_bg_color #383838;
+@define-color popover_fg_color white;
+.sidebar {
+  background-color: @window_bg_color;
+}
+
+notebook entry {
+  background-color: mix(@view_bg_color,black,0.02);
+}
+
+popover.menu check,
+popover.menu radio {
+  transition: none;
+}
+
+levelbar > trough > block.high, levelbar > trough > block:not(.empty) {
+  background-color: @success_color;
+}
+
+
+button.suggested-action {
+  color: @success_fg_color;
+}
+
+
+button.suggested-action:not(.flat),
+button.suggested-action:checked:not(.flat) {
+  background-color: @success_bg_color;
+}
+
+
+button.flat.suggested-action {
+  color: @success_color;
+}
+
+splitbutton.suggested-action > button, splitbutton.suggested-action > menubutton > button {
+  color: @success_fg_color;
+}
+
+splitbutton.suggested-action > button, splitbutton.suggested-action > button:checked, splitbutton.suggested-action > menubutton > button, splitbutton.suggested-action > menubutton > button:checked {
+  background-color: @success_bg_color;
+}
+
+
+button,
+link {
+  font-weight: normal;
+}

--- a/themes/yaru-purple-dark/gtk.scss
+++ b/themes/yaru-purple-dark/gtk.scss
@@ -1,0 +1,14 @@
+// General guidelines:
+// - very unlikely you want to edit something else than _common.scss
+// - keep the number of defined colors to a minimum, use the color blending functions if
+//   you need a subtle shade
+// - if you need to inverse a color function use the @if directive to match for dark $variant
+
+$variant: 'light';
+
+@import 'palette';
+@import 'defaults';
+@import 'functions';
+@import 'colors';
+@import 'tweaks';
+

--- a/themes/yaru-purple-dark/parse-sass.sh
+++ b/themes/yaru-purple-dark/parse-sass.sh
@@ -1,0 +1,12 @@
+#! /bin/bash
+
+if [ ! "$(which sassc 2> /dev/null)" ]; then
+   echo sassc needs to be installed to generate the css.
+   exit 1
+fi
+
+SASSC_OPT="-M -t expanded"
+
+echo Generating the css...
+
+sassc $SASSC_OPT gtk-dark.scss gtk.css

--- a/themes/yaru-purple/_colors.scss
+++ b/themes/yaru-purple/_colors.scss
@@ -1,0 +1,35 @@
+$accent_bg_color: gtkcolor(accent_bg_color);
+$accent_fg_color: gtkcolor(accent_fg_color);
+$accent_color: gtkcolor(accent_color);
+
+$destructive_bg_color: gtkcolor(destructive_bg_color);
+$destructive_fg_color: gtkcolor(destructive_fg_color);
+$destructive_color: gtkcolor(destructive_color);
+
+$success_bg_color: gtkcolor(success_bg_color);
+$success_fg_color: gtkcolor(success_fg_color);
+$success_color: gtkcolor(success_color);
+
+$warning_bg_color: gtkcolor(warning_bg_color);
+$warning_fg_color: gtkcolor(warning_fg_color);
+$warning_color: gtkcolor(warning_color);
+
+$error_bg_color: gtkcolor(error_bg_color);
+$error_fg_color: gtkcolor(error_fg_color);
+$error_color: gtkcolor(error_color);
+
+$window_bg_color: gtkcolor(window_bg_color);
+$window_fg_color: gtkcolor(window_fg_color);
+
+$view_bg_color: gtkcolor(view_bg_color);
+$view_fg_color: gtkcolor(view_fg_color);
+
+$headerbar_bg_color: gtkcolor(headerbar_bg_color);
+$headerbar_fg_color: gtkcolor(headerbar_fg_color);
+$headerbar_backdrop_color: gtkcolor(headerbar_backdrop_color);
+
+$card_bg_color: gtkcolor(card_bg_color);
+$card_fg_color: gtkcolor(card_fg_color);
+
+$popover_bg_color: gtkcolor(popover_bg_color);
+$popover_fg_color: gtkcolor(popover_fg_color);

--- a/themes/yaru-purple/_defaults.scss
+++ b/themes/yaru-purple/_defaults.scss
@@ -1,0 +1,53 @@
+/* GTK NAMED COLORS
+   ----------------
+   use responsibly! */
+
+// Sass thinks we're using the colors in the variables as strings and may shoot
+// warning, it's innocuous and can be defeated by using #{$var}.
+
+// These are the colors apps are can override. We define the defaults here and
+// define variables for them in _colors.scss
+
+// The main accent color and the matching text value
+@define-color accent_bg_color @yaru_accent_bg_color;
+@define-color accent_fg_color @light_1;
+@define-color accent_color @yaru_accent_bg_color;
+
+// destructive-action buttons
+@define-color destructive_bg_color @red_4;
+@define-color destructive_fg_color @light_1;
+@define-color destructive_color @red_4;
+
+// Levelbars, entries, labels and infobars. These don't need text colors
+@define-color success_bg_color @green_4;
+@define-color success_fg_color @light_1;
+@define-color success_color @green_4;
+
+@define-color warning_bg_color @yellow_5;
+@define-color warning_fg_color @light_1;
+@define-color warning_color @yellow_5;
+
+@define-color error_bg_color @red_4;
+@define-color error_fg_color @light_1;
+@define-color error_color @red_4;
+
+// Window
+@define-color window_bg_color #{if($variant == 'light', #fafafa, lighten(#181818, 8%))};
+@define-color window_fg_color #{if($variant=='light', '@dark_3', '@light_2')};
+
+// Views - e.g. text view or tree view
+@define-color view_bg_color #{if($variant == 'light', #ffffff, #1e1e1e)};
+@define-color view_fg_color #{if($variant == 'light', #000000, #ffffff)};
+
+// Header bar, search bar, tab bar
+@define-color headerbar_bg_color #{if($variant == 'light', #ebebeb, #303030)};
+@define-color headerbar_fg_color #{if($variant == 'light', transparentize(black, .2), white)};
+@define-color headerbar_backdrop_color @window_bg_color;
+
+// Cards, boxed lists
+@define-color card_bg_color #{if($variant == 'light', #ffffff, transparentize(white, .92))};
+@define-color card_fg_color #{if($variant == 'light', transparentize(black, .2), white)};
+
+// Popovers
+@define-color popover_bg_color #{if($variant == 'light', #ffffff, #383838)};
+@define-color popover_fg_color #{if($variant == 'light', transparentize(black, .2), white)};

--- a/themes/yaru-purple/_functions.scss
+++ b/themes/yaru-purple/_functions.scss
@@ -1,0 +1,16 @@
+@function gtkalpha($c,$a) {
+  @return unquote("alpha(#{$c},#{$a})");
+}
+
+@function gtkmix($c1,$c2,$r) {
+  $ratio: 1 -  $r / 100%; // match SCSS mix()
+  @return unquote("mix(#{$c1},#{$c2},#{$ratio})");
+}
+
+@function gtkshade($c,$s) {
+  @return unquote("shade(#{$c},#{$s})");
+}
+
+@function gtkcolor($c) {
+  @return unquote("@#{$c}");
+}

--- a/themes/yaru-purple/_palette.scss
+++ b/themes/yaru-purple/_palette.scss
@@ -1,0 +1,110 @@
+$blue_1: #75d3f4;
+$blue_2: #47c4f1;
+$blue_3: #19B6EE; // Yaru blue
+$blue_4: #007aa6; // Yaru linkblue
+$blue_5: #335280; // Yaru darkblue
+$green_1: #5AED70;
+$green_2: #47D35C;
+$green_3: #34B948;
+$green_4: #219E34;
+$green_5: #0e8420; // Yaru green
+$yellow_1: #FCCD87;
+$yellow_2: #FBC16A;
+$yellow_3: #FBB44C;
+$yellow_4: #FAA82F;
+$yellow_5: #F99B11; // Yaru yellow
+$orange_1: #F29879;
+$orange_2: #F08763;
+$orange_3: #ED764D;
+$orange_4: #EB6536;
+$orange_5: #E95420; // Yaru orange
+$red_1: #EA485C;
+$red_2: #DE374C;
+$red_3: #D3273B;
+$red_4: #c7162b; // Yaru red
+$red_5: #a91224;
+$purple_1: #924D8B; // Yaru aubergine
+$purple_2: #762572; // Yaru purple
+$purple_3: #77216F; // Yaru light aubergine
+$purple_4: #5E2750; // Yaru mid aubergine
+$purple_5: #2C001E; // Yaru dark aubergine
+$brown_1: #E1B289;
+$brown_2: #C5976E;
+$brown_3: #AA7B53;
+$brown_4: #8E6038;
+$brown_5: #72441D;
+$light_1: #FFFFFF;
+$light_2: #F7F7F7; // Yaru porcelain
+$light_3: #CCC; // Yaru silk
+$light_4: #AEA79F; // Yaru warm gray
+$light_5: #878787; // Yaru ash
+$dark_1: #666666; // Yaru graphite
+$dark_2: #5D5D5D; // Yaru slate
+$dark_3: #3D3D3D; // Yaru inkstone
+$dark_4: #181818; // Yaru jet
+$dark_5: #000000;
+
+// Ubuntu accent colors
+$default: $orange_5;
+$bark: #787859;
+$sage: #657B69;
+$olive: #4B8501;
+$viridian: #03875B;
+$prussiangreen: #308280;
+$blue: #0073E5;
+$purple: #7764D8;
+$magenta: #B34CB3;
+$red: #DA3450;
+
+$yaru_accent_bg_color: $purple !default;
+@define-color yaru_accent_bg_color #{$yaru_accent_bg_color};
+
+
+// Sass thinks we're using the colors in the variables as strings and may shoot
+// warning, it's innocuous and can be defeated by using #{$var}.
+
+@define-color blue_1 #{$blue_1};
+@define-color blue_2 #{$blue_2};
+@define-color blue_3 #{$blue_3};
+@define-color blue_4 #{$blue_4};
+@define-color blue_5 #{$blue_5};
+@define-color green_1 #{$green_1};
+@define-color green_2 #{$green_2};
+@define-color green_3 #{$green_3};
+@define-color green_4 #{$green_4};
+@define-color green_5 #{$green_5};
+@define-color yellow_1 #{$yellow_1};
+@define-color yellow_2 #{$yellow_2};
+@define-color yellow_3 #{$yellow_3};
+@define-color yellow_4 #{$yellow_4};
+@define-color yellow_5 #{$yellow_5};
+@define-color orange_1 #{$orange_1};
+@define-color orange_2 #{$orange_2};
+@define-color orange_3 #{$orange_3};
+@define-color orange_4 #{$orange_4};
+@define-color orange_5 #{$orange_5};
+@define-color red_1 #{$red_1};
+@define-color red_2 #{$red_2};
+@define-color red_3 #{$red_3};
+@define-color red_4 #{$red_4};
+@define-color red_5 #{$red_5};
+@define-color purple_1 #{$purple_1};
+@define-color purple_2 #{$purple_2};
+@define-color purple_3 #{$purple_3};
+@define-color purple_4 #{$purple_4};
+@define-color purple_5 #{$purple_5};
+@define-color brown_1 #{$brown_1};
+@define-color brown_2 #{$brown_2};
+@define-color brown_3 #{$brown_3};
+@define-color brown_4 #{$brown_4};
+@define-color brown_5 #{$brown_5};
+@define-color light_1 #{$light_1};
+@define-color light_2 #{$light_2};
+@define-color light_3 #{$light_3};
+@define-color light_4 #{$light_4};
+@define-color light_5 #{$light_5};
+@define-color dark_1 #{$dark_1};
+@define-color dark_2 #{$dark_2};
+@define-color dark_3 #{$dark_3};
+@define-color dark_4 #{$dark_4};
+@define-color dark_5 #{$dark_5};

--- a/themes/yaru-purple/_tweaks.scss
+++ b/themes/yaru-purple/_tweaks.scss
@@ -1,0 +1,73 @@
+// Reducing the amount of the palette's background colors to two
+.sidebar {
+	background-color: $window_bg_color;
+}
+
+// Entries drown if drawn on widgets with $base_color
+// Fixing this at least for notebooks, since entries on tabs is a common pattern
+// Remove this when upstream makes entries have a light border in the dark theme
+@if $variant== "dark" {
+	notebook entry {
+			background-color: gtkmix($view_bg_color, black, 98%);
+	}
+}
+
+// Fix popover wiggling effect (see #2903)
+popover.menu {
+	check,
+	radio {
+			transition: none;
+	}
+}
+
+// Use our own palette for high and not empty levelbar
+levelbar {
+	> trough {
+			> block {
+					&.high,
+					&:not(.empty) {
+							background-color: $success_color;
+					}
+			}
+	}
+}
+
+// Green suggested buttons
+%button,
+button {
+	&.suggested-action {
+			color: $success_fg_color;
+
+			&,
+			&:checked {
+					&:not(.flat) {
+							background-color: $success_bg_color;
+					}
+			}
+	}
+
+	&.flat {
+			&.suggested-action {
+					color: $success_color;
+			}
+	}
+}
+
+splitbutton {
+	&.suggested-action {
+			> button, > menubutton > button {
+					color: $success_fg_color;
+	
+					&, &:checked {
+							background-color: $success_bg_color;
+					}
+			}
+	}
+}
+
+%button,
+button,
+%link,
+link {
+	font-weight: normal;
+}

--- a/themes/yaru-purple/gtk-dark.scss
+++ b/themes/yaru-purple/gtk-dark.scss
@@ -1,0 +1,13 @@
+// General guidelines:
+// - very unlikely you want to edit something else than _common.scss
+// - keep the number of defined colors to a minimum, use the color blending functions if
+//   you need a subtle shade
+// - if you need to inverse a color function use the @if directive to match for dark $variant
+
+$variant: 'dark';
+
+@import 'palette';
+@import 'defaults';
+@import 'functions';
+@import 'colors';
+@import 'tweaks';

--- a/themes/yaru-purple/gtk.css
+++ b/themes/yaru-purple/gtk.css
@@ -1,0 +1,117 @@
+@define-color yaru_accent_bg_color #7764D8;
+@define-color blue_1 #75d3f4;
+@define-color blue_2 #47c4f1;
+@define-color blue_3 #19B6EE;
+@define-color blue_4 #007aa6;
+@define-color blue_5 #335280;
+@define-color green_1 #5AED70;
+@define-color green_2 #47D35C;
+@define-color green_3 #34B948;
+@define-color green_4 #219E34;
+@define-color green_5 #0e8420;
+@define-color yellow_1 #FCCD87;
+@define-color yellow_2 #FBC16A;
+@define-color yellow_3 #FBB44C;
+@define-color yellow_4 #FAA82F;
+@define-color yellow_5 #F99B11;
+@define-color orange_1 #F29879;
+@define-color orange_2 #F08763;
+@define-color orange_3 #ED764D;
+@define-color orange_4 #EB6536;
+@define-color orange_5 #E95420;
+@define-color red_1 #EA485C;
+@define-color red_2 #DE374C;
+@define-color red_3 #D3273B;
+@define-color red_4 #c7162b;
+@define-color red_5 #a91224;
+@define-color purple_1 #924D8B;
+@define-color purple_2 #762572;
+@define-color purple_3 #77216F;
+@define-color purple_4 #5E2750;
+@define-color purple_5 #2C001E;
+@define-color brown_1 #E1B289;
+@define-color brown_2 #C5976E;
+@define-color brown_3 #AA7B53;
+@define-color brown_4 #8E6038;
+@define-color brown_5 #72441D;
+@define-color light_1 #FFFFFF;
+@define-color light_2 #F7F7F7;
+@define-color light_3 #CCC;
+@define-color light_4 #AEA79F;
+@define-color light_5 #878787;
+@define-color dark_1 #666666;
+@define-color dark_2 #5D5D5D;
+@define-color dark_3 #3D3D3D;
+@define-color dark_4 #181818;
+@define-color dark_5 #000000;
+/* GTK NAMED COLORS
+   ----------------
+   use responsibly! */
+@define-color accent_bg_color @yaru_accent_bg_color;
+@define-color accent_fg_color @light_1;
+@define-color accent_color @yaru_accent_bg_color;
+@define-color destructive_bg_color @red_4;
+@define-color destructive_fg_color @light_1;
+@define-color destructive_color @red_4;
+@define-color success_bg_color @green_4;
+@define-color success_fg_color @light_1;
+@define-color success_color @green_4;
+@define-color warning_bg_color @yellow_5;
+@define-color warning_fg_color @light_1;
+@define-color warning_color @yellow_5;
+@define-color error_bg_color @red_4;
+@define-color error_fg_color @light_1;
+@define-color error_color @red_4;
+@define-color window_bg_color #fafafa;
+@define-color window_fg_color @dark_3;
+@define-color view_bg_color #ffffff;
+@define-color view_fg_color #000000;
+@define-color headerbar_bg_color #ebebeb;
+@define-color headerbar_fg_color rgba(0, 0, 0, 0.8);
+@define-color headerbar_backdrop_color @window_bg_color;
+@define-color card_bg_color #ffffff;
+@define-color card_fg_color rgba(0, 0, 0, 0.8);
+@define-color popover_bg_color #ffffff;
+@define-color popover_fg_color rgba(0, 0, 0, 0.8);
+.sidebar {
+  background-color: @window_bg_color;
+}
+
+popover.menu check,
+popover.menu radio {
+  transition: none;
+}
+
+levelbar > trough > block.high, levelbar > trough > block:not(.empty) {
+  background-color: @success_color;
+}
+
+
+button.suggested-action {
+  color: @success_fg_color;
+}
+
+
+button.suggested-action:not(.flat),
+button.suggested-action:checked:not(.flat) {
+  background-color: @success_bg_color;
+}
+
+
+button.flat.suggested-action {
+  color: @success_color;
+}
+
+splitbutton.suggested-action > button, splitbutton.suggested-action > menubutton > button {
+  color: @success_fg_color;
+}
+
+splitbutton.suggested-action > button, splitbutton.suggested-action > button:checked, splitbutton.suggested-action > menubutton > button, splitbutton.suggested-action > menubutton > button:checked {
+  background-color: @success_bg_color;
+}
+
+
+button,
+link {
+  font-weight: normal;
+}

--- a/themes/yaru-purple/gtk.scss
+++ b/themes/yaru-purple/gtk.scss
@@ -1,0 +1,14 @@
+// General guidelines:
+// - very unlikely you want to edit something else than _common.scss
+// - keep the number of defined colors to a minimum, use the color blending functions if
+//   you need a subtle shade
+// - if you need to inverse a color function use the @if directive to match for dark $variant
+
+$variant: 'light';
+
+@import 'palette';
+@import 'defaults';
+@import 'functions';
+@import 'colors';
+@import 'tweaks';
+

--- a/themes/yaru-purple/parse-sass.sh
+++ b/themes/yaru-purple/parse-sass.sh
@@ -1,0 +1,12 @@
+#! /bin/bash
+
+if [ ! "$(which sassc 2> /dev/null)" ]; then
+   echo sassc needs to be installed to generate the css.
+   exit 1
+fi
+
+SASSC_OPT="-M -t expanded"
+
+echo Generating the css...
+
+sassc $SASSC_OPT gtk.scss gtk.css

--- a/themes/yaru-red-dark/_colors.scss
+++ b/themes/yaru-red-dark/_colors.scss
@@ -1,0 +1,35 @@
+$accent_bg_color: gtkcolor(accent_bg_color);
+$accent_fg_color: gtkcolor(accent_fg_color);
+$accent_color: gtkcolor(accent_color);
+
+$destructive_bg_color: gtkcolor(destructive_bg_color);
+$destructive_fg_color: gtkcolor(destructive_fg_color);
+$destructive_color: gtkcolor(destructive_color);
+
+$success_bg_color: gtkcolor(success_bg_color);
+$success_fg_color: gtkcolor(success_fg_color);
+$success_color: gtkcolor(success_color);
+
+$warning_bg_color: gtkcolor(warning_bg_color);
+$warning_fg_color: gtkcolor(warning_fg_color);
+$warning_color: gtkcolor(warning_color);
+
+$error_bg_color: gtkcolor(error_bg_color);
+$error_fg_color: gtkcolor(error_fg_color);
+$error_color: gtkcolor(error_color);
+
+$window_bg_color: gtkcolor(window_bg_color);
+$window_fg_color: gtkcolor(window_fg_color);
+
+$view_bg_color: gtkcolor(view_bg_color);
+$view_fg_color: gtkcolor(view_fg_color);
+
+$headerbar_bg_color: gtkcolor(headerbar_bg_color);
+$headerbar_fg_color: gtkcolor(headerbar_fg_color);
+$headerbar_backdrop_color: gtkcolor(headerbar_backdrop_color);
+
+$card_bg_color: gtkcolor(card_bg_color);
+$card_fg_color: gtkcolor(card_fg_color);
+
+$popover_bg_color: gtkcolor(popover_bg_color);
+$popover_fg_color: gtkcolor(popover_fg_color);

--- a/themes/yaru-red-dark/_defaults.scss
+++ b/themes/yaru-red-dark/_defaults.scss
@@ -1,0 +1,53 @@
+/* GTK NAMED COLORS
+   ----------------
+   use responsibly! */
+
+// Sass thinks we're using the colors in the variables as strings and may shoot
+// warning, it's innocuous and can be defeated by using #{$var}.
+
+// These are the colors apps are can override. We define the defaults here and
+// define variables for them in _colors.scss
+
+// The main accent color and the matching text value
+@define-color accent_bg_color @yaru_accent_bg_color;
+@define-color accent_fg_color @light_1;
+@define-color accent_color @yaru_accent_bg_color;
+
+// destructive-action buttons
+@define-color destructive_bg_color @red_4;
+@define-color destructive_fg_color @light_1;
+@define-color destructive_color @red_4;
+
+// Levelbars, entries, labels and infobars. These don't need text colors
+@define-color success_bg_color @green_4;
+@define-color success_fg_color @light_1;
+@define-color success_color @green_4;
+
+@define-color warning_bg_color @yellow_5;
+@define-color warning_fg_color @light_1;
+@define-color warning_color @yellow_5;
+
+@define-color error_bg_color @red_4;
+@define-color error_fg_color @light_1;
+@define-color error_color @red_4;
+
+// Window
+@define-color window_bg_color #{if($variant == 'light', #fafafa, lighten(#181818, 8%))};
+@define-color window_fg_color #{if($variant=='light', '@dark_3', '@light_2')};
+
+// Views - e.g. text view or tree view
+@define-color view_bg_color #{if($variant == 'light', #ffffff, #1e1e1e)};
+@define-color view_fg_color #{if($variant == 'light', #000000, #ffffff)};
+
+// Header bar, search bar, tab bar
+@define-color headerbar_bg_color #{if($variant == 'light', #ebebeb, #303030)};
+@define-color headerbar_fg_color #{if($variant == 'light', transparentize(black, .2), white)};
+@define-color headerbar_backdrop_color @window_bg_color;
+
+// Cards, boxed lists
+@define-color card_bg_color #{if($variant == 'light', #ffffff, transparentize(white, .92))};
+@define-color card_fg_color #{if($variant == 'light', transparentize(black, .2), white)};
+
+// Popovers
+@define-color popover_bg_color #{if($variant == 'light', #ffffff, #383838)};
+@define-color popover_fg_color #{if($variant == 'light', transparentize(black, .2), white)};

--- a/themes/yaru-red-dark/_functions.scss
+++ b/themes/yaru-red-dark/_functions.scss
@@ -1,0 +1,16 @@
+@function gtkalpha($c,$a) {
+  @return unquote("alpha(#{$c},#{$a})");
+}
+
+@function gtkmix($c1,$c2,$r) {
+  $ratio: 1 -  $r / 100%; // match SCSS mix()
+  @return unquote("mix(#{$c1},#{$c2},#{$ratio})");
+}
+
+@function gtkshade($c,$s) {
+  @return unquote("shade(#{$c},#{$s})");
+}
+
+@function gtkcolor($c) {
+  @return unquote("@#{$c}");
+}

--- a/themes/yaru-red-dark/_palette.scss
+++ b/themes/yaru-red-dark/_palette.scss
@@ -1,0 +1,110 @@
+$blue_1: #75d3f4;
+$blue_2: #47c4f1;
+$blue_3: #19B6EE; // Yaru blue
+$blue_4: #007aa6; // Yaru linkblue
+$blue_5: #335280; // Yaru darkblue
+$green_1: #5AED70;
+$green_2: #47D35C;
+$green_3: #34B948;
+$green_4: #219E34;
+$green_5: #0e8420; // Yaru green
+$yellow_1: #FCCD87;
+$yellow_2: #FBC16A;
+$yellow_3: #FBB44C;
+$yellow_4: #FAA82F;
+$yellow_5: #F99B11; // Yaru yellow
+$orange_1: #F29879;
+$orange_2: #F08763;
+$orange_3: #ED764D;
+$orange_4: #EB6536;
+$orange_5: #E95420; // Yaru orange
+$red_1: #EA485C;
+$red_2: #DE374C;
+$red_3: #D3273B;
+$red_4: #c7162b; // Yaru red
+$red_5: #a91224;
+$purple_1: #924D8B; // Yaru aubergine
+$purple_2: #762572; // Yaru purple
+$purple_3: #77216F; // Yaru light aubergine
+$purple_4: #5E2750; // Yaru mid aubergine
+$purple_5: #2C001E; // Yaru dark aubergine
+$brown_1: #E1B289;
+$brown_2: #C5976E;
+$brown_3: #AA7B53;
+$brown_4: #8E6038;
+$brown_5: #72441D;
+$light_1: #FFFFFF;
+$light_2: #F7F7F7; // Yaru porcelain
+$light_3: #CCC; // Yaru silk
+$light_4: #AEA79F; // Yaru warm gray
+$light_5: #878787; // Yaru ash
+$dark_1: #666666; // Yaru graphite
+$dark_2: #5D5D5D; // Yaru slate
+$dark_3: #3D3D3D; // Yaru inkstone
+$dark_4: #181818; // Yaru jet
+$dark_5: #000000;
+
+// Ubuntu accent colors
+$default: $orange_5;
+$bark: #787859;
+$sage: #657B69;
+$olive: #4B8501;
+$viridian: #03875B;
+$prussiangreen: #308280;
+$blue: #0073E5;
+$purple: #7764D8;
+$magenta: #B34CB3;
+$red: #DA3450;
+
+$yaru_accent_bg_color: $red !default;
+@define-color yaru_accent_bg_color #{$yaru_accent_bg_color};
+
+
+// Sass thinks we're using the colors in the variables as strings and may shoot
+// warning, it's innocuous and can be defeated by using #{$var}.
+
+@define-color blue_1 #{$blue_1};
+@define-color blue_2 #{$blue_2};
+@define-color blue_3 #{$blue_3};
+@define-color blue_4 #{$blue_4};
+@define-color blue_5 #{$blue_5};
+@define-color green_1 #{$green_1};
+@define-color green_2 #{$green_2};
+@define-color green_3 #{$green_3};
+@define-color green_4 #{$green_4};
+@define-color green_5 #{$green_5};
+@define-color yellow_1 #{$yellow_1};
+@define-color yellow_2 #{$yellow_2};
+@define-color yellow_3 #{$yellow_3};
+@define-color yellow_4 #{$yellow_4};
+@define-color yellow_5 #{$yellow_5};
+@define-color orange_1 #{$orange_1};
+@define-color orange_2 #{$orange_2};
+@define-color orange_3 #{$orange_3};
+@define-color orange_4 #{$orange_4};
+@define-color orange_5 #{$orange_5};
+@define-color red_1 #{$red_1};
+@define-color red_2 #{$red_2};
+@define-color red_3 #{$red_3};
+@define-color red_4 #{$red_4};
+@define-color red_5 #{$red_5};
+@define-color purple_1 #{$purple_1};
+@define-color purple_2 #{$purple_2};
+@define-color purple_3 #{$purple_3};
+@define-color purple_4 #{$purple_4};
+@define-color purple_5 #{$purple_5};
+@define-color brown_1 #{$brown_1};
+@define-color brown_2 #{$brown_2};
+@define-color brown_3 #{$brown_3};
+@define-color brown_4 #{$brown_4};
+@define-color brown_5 #{$brown_5};
+@define-color light_1 #{$light_1};
+@define-color light_2 #{$light_2};
+@define-color light_3 #{$light_3};
+@define-color light_4 #{$light_4};
+@define-color light_5 #{$light_5};
+@define-color dark_1 #{$dark_1};
+@define-color dark_2 #{$dark_2};
+@define-color dark_3 #{$dark_3};
+@define-color dark_4 #{$dark_4};
+@define-color dark_5 #{$dark_5};

--- a/themes/yaru-red-dark/_tweaks.scss
+++ b/themes/yaru-red-dark/_tweaks.scss
@@ -1,0 +1,73 @@
+// Reducing the amount of the palette's background colors to two
+.sidebar {
+	background-color: $window_bg_color;
+}
+
+// Entries drown if drawn on widgets with $base_color
+// Fixing this at least for notebooks, since entries on tabs is a common pattern
+// Remove this when upstream makes entries have a light border in the dark theme
+@if $variant== "dark" {
+	notebook entry {
+			background-color: gtkmix($view_bg_color, black, 98%);
+	}
+}
+
+// Fix popover wiggling effect (see #2903)
+popover.menu {
+	check,
+	radio {
+			transition: none;
+	}
+}
+
+// Use our own palette for high and not empty levelbar
+levelbar {
+	> trough {
+			> block {
+					&.high,
+					&:not(.empty) {
+							background-color: $success_color;
+					}
+			}
+	}
+}
+
+// Green suggested buttons
+%button,
+button {
+	&.suggested-action {
+			color: $success_fg_color;
+
+			&,
+			&:checked {
+					&:not(.flat) {
+							background-color: $success_bg_color;
+					}
+			}
+	}
+
+	&.flat {
+			&.suggested-action {
+					color: $success_color;
+			}
+	}
+}
+
+splitbutton {
+	&.suggested-action {
+			> button, > menubutton > button {
+					color: $success_fg_color;
+	
+					&, &:checked {
+							background-color: $success_bg_color;
+					}
+			}
+	}
+}
+
+%button,
+button,
+%link,
+link {
+	font-weight: normal;
+}

--- a/themes/yaru-red-dark/gtk-dark.scss
+++ b/themes/yaru-red-dark/gtk-dark.scss
@@ -1,0 +1,13 @@
+// General guidelines:
+// - very unlikely you want to edit something else than _common.scss
+// - keep the number of defined colors to a minimum, use the color blending functions if
+//   you need a subtle shade
+// - if you need to inverse a color function use the @if directive to match for dark $variant
+
+$variant: 'dark';
+
+@import 'palette';
+@import 'defaults';
+@import 'functions';
+@import 'colors';
+@import 'tweaks';

--- a/themes/yaru-red-dark/gtk.css
+++ b/themes/yaru-red-dark/gtk.css
@@ -1,0 +1,121 @@
+@define-color yaru_accent_bg_color #DA3450;
+@define-color blue_1 #75d3f4;
+@define-color blue_2 #47c4f1;
+@define-color blue_3 #19B6EE;
+@define-color blue_4 #007aa6;
+@define-color blue_5 #335280;
+@define-color green_1 #5AED70;
+@define-color green_2 #47D35C;
+@define-color green_3 #34B948;
+@define-color green_4 #219E34;
+@define-color green_5 #0e8420;
+@define-color yellow_1 #FCCD87;
+@define-color yellow_2 #FBC16A;
+@define-color yellow_3 #FBB44C;
+@define-color yellow_4 #FAA82F;
+@define-color yellow_5 #F99B11;
+@define-color orange_1 #F29879;
+@define-color orange_2 #F08763;
+@define-color orange_3 #ED764D;
+@define-color orange_4 #EB6536;
+@define-color orange_5 #E95420;
+@define-color red_1 #EA485C;
+@define-color red_2 #DE374C;
+@define-color red_3 #D3273B;
+@define-color red_4 #c7162b;
+@define-color red_5 #a91224;
+@define-color purple_1 #924D8B;
+@define-color purple_2 #762572;
+@define-color purple_3 #77216F;
+@define-color purple_4 #5E2750;
+@define-color purple_5 #2C001E;
+@define-color brown_1 #E1B289;
+@define-color brown_2 #C5976E;
+@define-color brown_3 #AA7B53;
+@define-color brown_4 #8E6038;
+@define-color brown_5 #72441D;
+@define-color light_1 #FFFFFF;
+@define-color light_2 #F7F7F7;
+@define-color light_3 #CCC;
+@define-color light_4 #AEA79F;
+@define-color light_5 #878787;
+@define-color dark_1 #666666;
+@define-color dark_2 #5D5D5D;
+@define-color dark_3 #3D3D3D;
+@define-color dark_4 #181818;
+@define-color dark_5 #000000;
+/* GTK NAMED COLORS
+   ----------------
+   use responsibly! */
+@define-color accent_bg_color @yaru_accent_bg_color;
+@define-color accent_fg_color @light_1;
+@define-color accent_color @yaru_accent_bg_color;
+@define-color destructive_bg_color @red_4;
+@define-color destructive_fg_color @light_1;
+@define-color destructive_color @red_4;
+@define-color success_bg_color @green_4;
+@define-color success_fg_color @light_1;
+@define-color success_color @green_4;
+@define-color warning_bg_color @yellow_5;
+@define-color warning_fg_color @light_1;
+@define-color warning_color @yellow_5;
+@define-color error_bg_color @red_4;
+@define-color error_fg_color @light_1;
+@define-color error_color @red_4;
+@define-color window_bg_color #2c2c2c;
+@define-color window_fg_color @light_2;
+@define-color view_bg_color #1e1e1e;
+@define-color view_fg_color #ffffff;
+@define-color headerbar_bg_color #303030;
+@define-color headerbar_fg_color white;
+@define-color headerbar_backdrop_color @window_bg_color;
+@define-color card_bg_color rgba(255, 255, 255, 0.08);
+@define-color card_fg_color white;
+@define-color popover_bg_color #383838;
+@define-color popover_fg_color white;
+.sidebar {
+  background-color: @window_bg_color;
+}
+
+notebook entry {
+  background-color: mix(@view_bg_color,black,0.02);
+}
+
+popover.menu check,
+popover.menu radio {
+  transition: none;
+}
+
+levelbar > trough > block.high, levelbar > trough > block:not(.empty) {
+  background-color: @success_color;
+}
+
+
+button.suggested-action {
+  color: @success_fg_color;
+}
+
+
+button.suggested-action:not(.flat),
+button.suggested-action:checked:not(.flat) {
+  background-color: @success_bg_color;
+}
+
+
+button.flat.suggested-action {
+  color: @success_color;
+}
+
+splitbutton.suggested-action > button, splitbutton.suggested-action > menubutton > button {
+  color: @success_fg_color;
+}
+
+splitbutton.suggested-action > button, splitbutton.suggested-action > button:checked, splitbutton.suggested-action > menubutton > button, splitbutton.suggested-action > menubutton > button:checked {
+  background-color: @success_bg_color;
+}
+
+
+button,
+link {
+  font-weight: normal;
+}

--- a/themes/yaru-red-dark/gtk.scss
+++ b/themes/yaru-red-dark/gtk.scss
@@ -1,0 +1,14 @@
+// General guidelines:
+// - very unlikely you want to edit something else than _common.scss
+// - keep the number of defined colors to a minimum, use the color blending functions if
+//   you need a subtle shade
+// - if you need to inverse a color function use the @if directive to match for dark $variant
+
+$variant: 'light';
+
+@import 'palette';
+@import 'defaults';
+@import 'functions';
+@import 'colors';
+@import 'tweaks';
+

--- a/themes/yaru-red-dark/parse-sass.sh
+++ b/themes/yaru-red-dark/parse-sass.sh
@@ -1,0 +1,12 @@
+#! /bin/bash
+
+if [ ! "$(which sassc 2> /dev/null)" ]; then
+   echo sassc needs to be installed to generate the css.
+   exit 1
+fi
+
+SASSC_OPT="-M -t expanded"
+
+echo Generating the css...
+
+sassc $SASSC_OPT gtk-dark.scss gtk.css

--- a/themes/yaru-red/_colors.scss
+++ b/themes/yaru-red/_colors.scss
@@ -1,0 +1,35 @@
+$accent_bg_color: gtkcolor(accent_bg_color);
+$accent_fg_color: gtkcolor(accent_fg_color);
+$accent_color: gtkcolor(accent_color);
+
+$destructive_bg_color: gtkcolor(destructive_bg_color);
+$destructive_fg_color: gtkcolor(destructive_fg_color);
+$destructive_color: gtkcolor(destructive_color);
+
+$success_bg_color: gtkcolor(success_bg_color);
+$success_fg_color: gtkcolor(success_fg_color);
+$success_color: gtkcolor(success_color);
+
+$warning_bg_color: gtkcolor(warning_bg_color);
+$warning_fg_color: gtkcolor(warning_fg_color);
+$warning_color: gtkcolor(warning_color);
+
+$error_bg_color: gtkcolor(error_bg_color);
+$error_fg_color: gtkcolor(error_fg_color);
+$error_color: gtkcolor(error_color);
+
+$window_bg_color: gtkcolor(window_bg_color);
+$window_fg_color: gtkcolor(window_fg_color);
+
+$view_bg_color: gtkcolor(view_bg_color);
+$view_fg_color: gtkcolor(view_fg_color);
+
+$headerbar_bg_color: gtkcolor(headerbar_bg_color);
+$headerbar_fg_color: gtkcolor(headerbar_fg_color);
+$headerbar_backdrop_color: gtkcolor(headerbar_backdrop_color);
+
+$card_bg_color: gtkcolor(card_bg_color);
+$card_fg_color: gtkcolor(card_fg_color);
+
+$popover_bg_color: gtkcolor(popover_bg_color);
+$popover_fg_color: gtkcolor(popover_fg_color);

--- a/themes/yaru-red/_defaults.scss
+++ b/themes/yaru-red/_defaults.scss
@@ -1,0 +1,53 @@
+/* GTK NAMED COLORS
+   ----------------
+   use responsibly! */
+
+// Sass thinks we're using the colors in the variables as strings and may shoot
+// warning, it's innocuous and can be defeated by using #{$var}.
+
+// These are the colors apps are can override. We define the defaults here and
+// define variables for them in _colors.scss
+
+// The main accent color and the matching text value
+@define-color accent_bg_color @yaru_accent_bg_color;
+@define-color accent_fg_color @light_1;
+@define-color accent_color @yaru_accent_bg_color;
+
+// destructive-action buttons
+@define-color destructive_bg_color @red_4;
+@define-color destructive_fg_color @light_1;
+@define-color destructive_color @red_4;
+
+// Levelbars, entries, labels and infobars. These don't need text colors
+@define-color success_bg_color @green_4;
+@define-color success_fg_color @light_1;
+@define-color success_color @green_4;
+
+@define-color warning_bg_color @yellow_5;
+@define-color warning_fg_color @light_1;
+@define-color warning_color @yellow_5;
+
+@define-color error_bg_color @red_4;
+@define-color error_fg_color @light_1;
+@define-color error_color @red_4;
+
+// Window
+@define-color window_bg_color #{if($variant == 'light', #fafafa, lighten(#181818, 8%))};
+@define-color window_fg_color #{if($variant=='light', '@dark_3', '@light_2')};
+
+// Views - e.g. text view or tree view
+@define-color view_bg_color #{if($variant == 'light', #ffffff, #1e1e1e)};
+@define-color view_fg_color #{if($variant == 'light', #000000, #ffffff)};
+
+// Header bar, search bar, tab bar
+@define-color headerbar_bg_color #{if($variant == 'light', #ebebeb, #303030)};
+@define-color headerbar_fg_color #{if($variant == 'light', transparentize(black, .2), white)};
+@define-color headerbar_backdrop_color @window_bg_color;
+
+// Cards, boxed lists
+@define-color card_bg_color #{if($variant == 'light', #ffffff, transparentize(white, .92))};
+@define-color card_fg_color #{if($variant == 'light', transparentize(black, .2), white)};
+
+// Popovers
+@define-color popover_bg_color #{if($variant == 'light', #ffffff, #383838)};
+@define-color popover_fg_color #{if($variant == 'light', transparentize(black, .2), white)};

--- a/themes/yaru-red/_functions.scss
+++ b/themes/yaru-red/_functions.scss
@@ -1,0 +1,16 @@
+@function gtkalpha($c,$a) {
+  @return unquote("alpha(#{$c},#{$a})");
+}
+
+@function gtkmix($c1,$c2,$r) {
+  $ratio: 1 -  $r / 100%; // match SCSS mix()
+  @return unquote("mix(#{$c1},#{$c2},#{$ratio})");
+}
+
+@function gtkshade($c,$s) {
+  @return unquote("shade(#{$c},#{$s})");
+}
+
+@function gtkcolor($c) {
+  @return unquote("@#{$c}");
+}

--- a/themes/yaru-red/_palette.scss
+++ b/themes/yaru-red/_palette.scss
@@ -1,0 +1,110 @@
+$blue_1: #75d3f4;
+$blue_2: #47c4f1;
+$blue_3: #19B6EE; // Yaru blue
+$blue_4: #007aa6; // Yaru linkblue
+$blue_5: #335280; // Yaru darkblue
+$green_1: #5AED70;
+$green_2: #47D35C;
+$green_3: #34B948;
+$green_4: #219E34;
+$green_5: #0e8420; // Yaru green
+$yellow_1: #FCCD87;
+$yellow_2: #FBC16A;
+$yellow_3: #FBB44C;
+$yellow_4: #FAA82F;
+$yellow_5: #F99B11; // Yaru yellow
+$orange_1: #F29879;
+$orange_2: #F08763;
+$orange_3: #ED764D;
+$orange_4: #EB6536;
+$orange_5: #E95420; // Yaru orange
+$red_1: #EA485C;
+$red_2: #DE374C;
+$red_3: #D3273B;
+$red_4: #c7162b; // Yaru red
+$red_5: #a91224;
+$purple_1: #924D8B; // Yaru aubergine
+$purple_2: #762572; // Yaru purple
+$purple_3: #77216F; // Yaru light aubergine
+$purple_4: #5E2750; // Yaru mid aubergine
+$purple_5: #2C001E; // Yaru dark aubergine
+$brown_1: #E1B289;
+$brown_2: #C5976E;
+$brown_3: #AA7B53;
+$brown_4: #8E6038;
+$brown_5: #72441D;
+$light_1: #FFFFFF;
+$light_2: #F7F7F7; // Yaru porcelain
+$light_3: #CCC; // Yaru silk
+$light_4: #AEA79F; // Yaru warm gray
+$light_5: #878787; // Yaru ash
+$dark_1: #666666; // Yaru graphite
+$dark_2: #5D5D5D; // Yaru slate
+$dark_3: #3D3D3D; // Yaru inkstone
+$dark_4: #181818; // Yaru jet
+$dark_5: #000000;
+
+// Ubuntu accent colors
+$default: $orange_5;
+$bark: #787859;
+$sage: #657B69;
+$olive: #4B8501;
+$viridian: #03875B;
+$prussiangreen: #308280;
+$blue: #0073E5;
+$purple: #7764D8;
+$magenta: #B34CB3;
+$red: #DA3450;
+
+$yaru_accent_bg_color: $red !default;
+@define-color yaru_accent_bg_color #{$yaru_accent_bg_color};
+
+
+// Sass thinks we're using the colors in the variables as strings and may shoot
+// warning, it's innocuous and can be defeated by using #{$var}.
+
+@define-color blue_1 #{$blue_1};
+@define-color blue_2 #{$blue_2};
+@define-color blue_3 #{$blue_3};
+@define-color blue_4 #{$blue_4};
+@define-color blue_5 #{$blue_5};
+@define-color green_1 #{$green_1};
+@define-color green_2 #{$green_2};
+@define-color green_3 #{$green_3};
+@define-color green_4 #{$green_4};
+@define-color green_5 #{$green_5};
+@define-color yellow_1 #{$yellow_1};
+@define-color yellow_2 #{$yellow_2};
+@define-color yellow_3 #{$yellow_3};
+@define-color yellow_4 #{$yellow_4};
+@define-color yellow_5 #{$yellow_5};
+@define-color orange_1 #{$orange_1};
+@define-color orange_2 #{$orange_2};
+@define-color orange_3 #{$orange_3};
+@define-color orange_4 #{$orange_4};
+@define-color orange_5 #{$orange_5};
+@define-color red_1 #{$red_1};
+@define-color red_2 #{$red_2};
+@define-color red_3 #{$red_3};
+@define-color red_4 #{$red_4};
+@define-color red_5 #{$red_5};
+@define-color purple_1 #{$purple_1};
+@define-color purple_2 #{$purple_2};
+@define-color purple_3 #{$purple_3};
+@define-color purple_4 #{$purple_4};
+@define-color purple_5 #{$purple_5};
+@define-color brown_1 #{$brown_1};
+@define-color brown_2 #{$brown_2};
+@define-color brown_3 #{$brown_3};
+@define-color brown_4 #{$brown_4};
+@define-color brown_5 #{$brown_5};
+@define-color light_1 #{$light_1};
+@define-color light_2 #{$light_2};
+@define-color light_3 #{$light_3};
+@define-color light_4 #{$light_4};
+@define-color light_5 #{$light_5};
+@define-color dark_1 #{$dark_1};
+@define-color dark_2 #{$dark_2};
+@define-color dark_3 #{$dark_3};
+@define-color dark_4 #{$dark_4};
+@define-color dark_5 #{$dark_5};

--- a/themes/yaru-red/_tweaks.scss
+++ b/themes/yaru-red/_tweaks.scss
@@ -1,0 +1,73 @@
+// Reducing the amount of the palette's background colors to two
+.sidebar {
+	background-color: $window_bg_color;
+}
+
+// Entries drown if drawn on widgets with $base_color
+// Fixing this at least for notebooks, since entries on tabs is a common pattern
+// Remove this when upstream makes entries have a light border in the dark theme
+@if $variant== "dark" {
+	notebook entry {
+			background-color: gtkmix($view_bg_color, black, 98%);
+	}
+}
+
+// Fix popover wiggling effect (see #2903)
+popover.menu {
+	check,
+	radio {
+			transition: none;
+	}
+}
+
+// Use our own palette for high and not empty levelbar
+levelbar {
+	> trough {
+			> block {
+					&.high,
+					&:not(.empty) {
+							background-color: $success_color;
+					}
+			}
+	}
+}
+
+// Green suggested buttons
+%button,
+button {
+	&.suggested-action {
+			color: $success_fg_color;
+
+			&,
+			&:checked {
+					&:not(.flat) {
+							background-color: $success_bg_color;
+					}
+			}
+	}
+
+	&.flat {
+			&.suggested-action {
+					color: $success_color;
+			}
+	}
+}
+
+splitbutton {
+	&.suggested-action {
+			> button, > menubutton > button {
+					color: $success_fg_color;
+	
+					&, &:checked {
+							background-color: $success_bg_color;
+					}
+			}
+	}
+}
+
+%button,
+button,
+%link,
+link {
+	font-weight: normal;
+}

--- a/themes/yaru-red/gtk-dark.scss
+++ b/themes/yaru-red/gtk-dark.scss
@@ -1,0 +1,13 @@
+// General guidelines:
+// - very unlikely you want to edit something else than _common.scss
+// - keep the number of defined colors to a minimum, use the color blending functions if
+//   you need a subtle shade
+// - if you need to inverse a color function use the @if directive to match for dark $variant
+
+$variant: 'dark';
+
+@import 'palette';
+@import 'defaults';
+@import 'functions';
+@import 'colors';
+@import 'tweaks';

--- a/themes/yaru-red/gtk.css
+++ b/themes/yaru-red/gtk.css
@@ -1,0 +1,117 @@
+@define-color yaru_accent_bg_color #DA3450;
+@define-color blue_1 #75d3f4;
+@define-color blue_2 #47c4f1;
+@define-color blue_3 #19B6EE;
+@define-color blue_4 #007aa6;
+@define-color blue_5 #335280;
+@define-color green_1 #5AED70;
+@define-color green_2 #47D35C;
+@define-color green_3 #34B948;
+@define-color green_4 #219E34;
+@define-color green_5 #0e8420;
+@define-color yellow_1 #FCCD87;
+@define-color yellow_2 #FBC16A;
+@define-color yellow_3 #FBB44C;
+@define-color yellow_4 #FAA82F;
+@define-color yellow_5 #F99B11;
+@define-color orange_1 #F29879;
+@define-color orange_2 #F08763;
+@define-color orange_3 #ED764D;
+@define-color orange_4 #EB6536;
+@define-color orange_5 #E95420;
+@define-color red_1 #EA485C;
+@define-color red_2 #DE374C;
+@define-color red_3 #D3273B;
+@define-color red_4 #c7162b;
+@define-color red_5 #a91224;
+@define-color purple_1 #924D8B;
+@define-color purple_2 #762572;
+@define-color purple_3 #77216F;
+@define-color purple_4 #5E2750;
+@define-color purple_5 #2C001E;
+@define-color brown_1 #E1B289;
+@define-color brown_2 #C5976E;
+@define-color brown_3 #AA7B53;
+@define-color brown_4 #8E6038;
+@define-color brown_5 #72441D;
+@define-color light_1 #FFFFFF;
+@define-color light_2 #F7F7F7;
+@define-color light_3 #CCC;
+@define-color light_4 #AEA79F;
+@define-color light_5 #878787;
+@define-color dark_1 #666666;
+@define-color dark_2 #5D5D5D;
+@define-color dark_3 #3D3D3D;
+@define-color dark_4 #181818;
+@define-color dark_5 #000000;
+/* GTK NAMED COLORS
+   ----------------
+   use responsibly! */
+@define-color accent_bg_color @yaru_accent_bg_color;
+@define-color accent_fg_color @light_1;
+@define-color accent_color @yaru_accent_bg_color;
+@define-color destructive_bg_color @red_4;
+@define-color destructive_fg_color @light_1;
+@define-color destructive_color @red_4;
+@define-color success_bg_color @green_4;
+@define-color success_fg_color @light_1;
+@define-color success_color @green_4;
+@define-color warning_bg_color @yellow_5;
+@define-color warning_fg_color @light_1;
+@define-color warning_color @yellow_5;
+@define-color error_bg_color @red_4;
+@define-color error_fg_color @light_1;
+@define-color error_color @red_4;
+@define-color window_bg_color #fafafa;
+@define-color window_fg_color @dark_3;
+@define-color view_bg_color #ffffff;
+@define-color view_fg_color #000000;
+@define-color headerbar_bg_color #ebebeb;
+@define-color headerbar_fg_color rgba(0, 0, 0, 0.8);
+@define-color headerbar_backdrop_color @window_bg_color;
+@define-color card_bg_color #ffffff;
+@define-color card_fg_color rgba(0, 0, 0, 0.8);
+@define-color popover_bg_color #ffffff;
+@define-color popover_fg_color rgba(0, 0, 0, 0.8);
+.sidebar {
+  background-color: @window_bg_color;
+}
+
+popover.menu check,
+popover.menu radio {
+  transition: none;
+}
+
+levelbar > trough > block.high, levelbar > trough > block:not(.empty) {
+  background-color: @success_color;
+}
+
+
+button.suggested-action {
+  color: @success_fg_color;
+}
+
+
+button.suggested-action:not(.flat),
+button.suggested-action:checked:not(.flat) {
+  background-color: @success_bg_color;
+}
+
+
+button.flat.suggested-action {
+  color: @success_color;
+}
+
+splitbutton.suggested-action > button, splitbutton.suggested-action > menubutton > button {
+  color: @success_fg_color;
+}
+
+splitbutton.suggested-action > button, splitbutton.suggested-action > button:checked, splitbutton.suggested-action > menubutton > button, splitbutton.suggested-action > menubutton > button:checked {
+  background-color: @success_bg_color;
+}
+
+
+button,
+link {
+  font-weight: normal;
+}

--- a/themes/yaru-red/gtk.scss
+++ b/themes/yaru-red/gtk.scss
@@ -1,0 +1,14 @@
+// General guidelines:
+// - very unlikely you want to edit something else than _common.scss
+// - keep the number of defined colors to a minimum, use the color blending functions if
+//   you need a subtle shade
+// - if you need to inverse a color function use the @if directive to match for dark $variant
+
+$variant: 'light';
+
+@import 'palette';
+@import 'defaults';
+@import 'functions';
+@import 'colors';
+@import 'tweaks';
+

--- a/themes/yaru-red/parse-sass.sh
+++ b/themes/yaru-red/parse-sass.sh
@@ -1,0 +1,12 @@
+#! /bin/bash
+
+if [ ! "$(which sassc 2> /dev/null)" ]; then
+   echo sassc needs to be installed to generate the css.
+   exit 1
+fi
+
+SASSC_OPT="-M -t expanded"
+
+echo Generating the css...
+
+sassc $SASSC_OPT gtk.scss gtk.css

--- a/themes/yaru-sage-dark/_colors.scss
+++ b/themes/yaru-sage-dark/_colors.scss
@@ -1,0 +1,35 @@
+$accent_bg_color: gtkcolor(accent_bg_color);
+$accent_fg_color: gtkcolor(accent_fg_color);
+$accent_color: gtkcolor(accent_color);
+
+$destructive_bg_color: gtkcolor(destructive_bg_color);
+$destructive_fg_color: gtkcolor(destructive_fg_color);
+$destructive_color: gtkcolor(destructive_color);
+
+$success_bg_color: gtkcolor(success_bg_color);
+$success_fg_color: gtkcolor(success_fg_color);
+$success_color: gtkcolor(success_color);
+
+$warning_bg_color: gtkcolor(warning_bg_color);
+$warning_fg_color: gtkcolor(warning_fg_color);
+$warning_color: gtkcolor(warning_color);
+
+$error_bg_color: gtkcolor(error_bg_color);
+$error_fg_color: gtkcolor(error_fg_color);
+$error_color: gtkcolor(error_color);
+
+$window_bg_color: gtkcolor(window_bg_color);
+$window_fg_color: gtkcolor(window_fg_color);
+
+$view_bg_color: gtkcolor(view_bg_color);
+$view_fg_color: gtkcolor(view_fg_color);
+
+$headerbar_bg_color: gtkcolor(headerbar_bg_color);
+$headerbar_fg_color: gtkcolor(headerbar_fg_color);
+$headerbar_backdrop_color: gtkcolor(headerbar_backdrop_color);
+
+$card_bg_color: gtkcolor(card_bg_color);
+$card_fg_color: gtkcolor(card_fg_color);
+
+$popover_bg_color: gtkcolor(popover_bg_color);
+$popover_fg_color: gtkcolor(popover_fg_color);

--- a/themes/yaru-sage-dark/_defaults.scss
+++ b/themes/yaru-sage-dark/_defaults.scss
@@ -1,0 +1,53 @@
+/* GTK NAMED COLORS
+   ----------------
+   use responsibly! */
+
+// Sass thinks we're using the colors in the variables as strings and may shoot
+// warning, it's innocuous and can be defeated by using #{$var}.
+
+// These are the colors apps are can override. We define the defaults here and
+// define variables for them in _colors.scss
+
+// The main accent color and the matching text value
+@define-color accent_bg_color @yaru_accent_bg_color;
+@define-color accent_fg_color @light_1;
+@define-color accent_color @yaru_accent_bg_color;
+
+// destructive-action buttons
+@define-color destructive_bg_color @red_4;
+@define-color destructive_fg_color @light_1;
+@define-color destructive_color @red_4;
+
+// Levelbars, entries, labels and infobars. These don't need text colors
+@define-color success_bg_color @green_4;
+@define-color success_fg_color @light_1;
+@define-color success_color @green_4;
+
+@define-color warning_bg_color @yellow_5;
+@define-color warning_fg_color @light_1;
+@define-color warning_color @yellow_5;
+
+@define-color error_bg_color @red_4;
+@define-color error_fg_color @light_1;
+@define-color error_color @red_4;
+
+// Window
+@define-color window_bg_color #{if($variant == 'light', #fafafa, lighten(#181818, 8%))};
+@define-color window_fg_color #{if($variant=='light', '@dark_3', '@light_2')};
+
+// Views - e.g. text view or tree view
+@define-color view_bg_color #{if($variant == 'light', #ffffff, #1e1e1e)};
+@define-color view_fg_color #{if($variant == 'light', #000000, #ffffff)};
+
+// Header bar, search bar, tab bar
+@define-color headerbar_bg_color #{if($variant == 'light', #ebebeb, #303030)};
+@define-color headerbar_fg_color #{if($variant == 'light', transparentize(black, .2), white)};
+@define-color headerbar_backdrop_color @window_bg_color;
+
+// Cards, boxed lists
+@define-color card_bg_color #{if($variant == 'light', #ffffff, transparentize(white, .92))};
+@define-color card_fg_color #{if($variant == 'light', transparentize(black, .2), white)};
+
+// Popovers
+@define-color popover_bg_color #{if($variant == 'light', #ffffff, #383838)};
+@define-color popover_fg_color #{if($variant == 'light', transparentize(black, .2), white)};

--- a/themes/yaru-sage-dark/_functions.scss
+++ b/themes/yaru-sage-dark/_functions.scss
@@ -1,0 +1,16 @@
+@function gtkalpha($c,$a) {
+  @return unquote("alpha(#{$c},#{$a})");
+}
+
+@function gtkmix($c1,$c2,$r) {
+  $ratio: 1 -  $r / 100%; // match SCSS mix()
+  @return unquote("mix(#{$c1},#{$c2},#{$ratio})");
+}
+
+@function gtkshade($c,$s) {
+  @return unquote("shade(#{$c},#{$s})");
+}
+
+@function gtkcolor($c) {
+  @return unquote("@#{$c}");
+}

--- a/themes/yaru-sage-dark/_palette.scss
+++ b/themes/yaru-sage-dark/_palette.scss
@@ -1,0 +1,110 @@
+$blue_1: #75d3f4;
+$blue_2: #47c4f1;
+$blue_3: #19B6EE; // Yaru blue
+$blue_4: #007aa6; // Yaru linkblue
+$blue_5: #335280; // Yaru darkblue
+$green_1: #5AED70;
+$green_2: #47D35C;
+$green_3: #34B948;
+$green_4: #219E34;
+$green_5: #0e8420; // Yaru green
+$yellow_1: #FCCD87;
+$yellow_2: #FBC16A;
+$yellow_3: #FBB44C;
+$yellow_4: #FAA82F;
+$yellow_5: #F99B11; // Yaru yellow
+$orange_1: #F29879;
+$orange_2: #F08763;
+$orange_3: #ED764D;
+$orange_4: #EB6536;
+$orange_5: #E95420; // Yaru orange
+$red_1: #EA485C;
+$red_2: #DE374C;
+$red_3: #D3273B;
+$red_4: #c7162b; // Yaru red
+$red_5: #a91224;
+$purple_1: #924D8B; // Yaru aubergine
+$purple_2: #762572; // Yaru purple
+$purple_3: #77216F; // Yaru light aubergine
+$purple_4: #5E2750; // Yaru mid aubergine
+$purple_5: #2C001E; // Yaru dark aubergine
+$brown_1: #E1B289;
+$brown_2: #C5976E;
+$brown_3: #AA7B53;
+$brown_4: #8E6038;
+$brown_5: #72441D;
+$light_1: #FFFFFF;
+$light_2: #F7F7F7; // Yaru porcelain
+$light_3: #CCC; // Yaru silk
+$light_4: #AEA79F; // Yaru warm gray
+$light_5: #878787; // Yaru ash
+$dark_1: #666666; // Yaru graphite
+$dark_2: #5D5D5D; // Yaru slate
+$dark_3: #3D3D3D; // Yaru inkstone
+$dark_4: #181818; // Yaru jet
+$dark_5: #000000;
+
+// Ubuntu accent colors
+$default: $orange_5;
+$bark: #787859;
+$sage: #657B69;
+$olive: #4B8501;
+$viridian: #03875B;
+$prussiangreen: #308280;
+$blue: #0073E5;
+$purple: #7764D8;
+$magenta: #B34CB3;
+$red: #DA3450;
+
+$yaru_accent_bg_color: $sage !default;
+@define-color yaru_accent_bg_color #{$yaru_accent_bg_color};
+
+
+// Sass thinks we're using the colors in the variables as strings and may shoot
+// warning, it's innocuous and can be defeated by using #{$var}.
+
+@define-color blue_1 #{$blue_1};
+@define-color blue_2 #{$blue_2};
+@define-color blue_3 #{$blue_3};
+@define-color blue_4 #{$blue_4};
+@define-color blue_5 #{$blue_5};
+@define-color green_1 #{$green_1};
+@define-color green_2 #{$green_2};
+@define-color green_3 #{$green_3};
+@define-color green_4 #{$green_4};
+@define-color green_5 #{$green_5};
+@define-color yellow_1 #{$yellow_1};
+@define-color yellow_2 #{$yellow_2};
+@define-color yellow_3 #{$yellow_3};
+@define-color yellow_4 #{$yellow_4};
+@define-color yellow_5 #{$yellow_5};
+@define-color orange_1 #{$orange_1};
+@define-color orange_2 #{$orange_2};
+@define-color orange_3 #{$orange_3};
+@define-color orange_4 #{$orange_4};
+@define-color orange_5 #{$orange_5};
+@define-color red_1 #{$red_1};
+@define-color red_2 #{$red_2};
+@define-color red_3 #{$red_3};
+@define-color red_4 #{$red_4};
+@define-color red_5 #{$red_5};
+@define-color purple_1 #{$purple_1};
+@define-color purple_2 #{$purple_2};
+@define-color purple_3 #{$purple_3};
+@define-color purple_4 #{$purple_4};
+@define-color purple_5 #{$purple_5};
+@define-color brown_1 #{$brown_1};
+@define-color brown_2 #{$brown_2};
+@define-color brown_3 #{$brown_3};
+@define-color brown_4 #{$brown_4};
+@define-color brown_5 #{$brown_5};
+@define-color light_1 #{$light_1};
+@define-color light_2 #{$light_2};
+@define-color light_3 #{$light_3};
+@define-color light_4 #{$light_4};
+@define-color light_5 #{$light_5};
+@define-color dark_1 #{$dark_1};
+@define-color dark_2 #{$dark_2};
+@define-color dark_3 #{$dark_3};
+@define-color dark_4 #{$dark_4};
+@define-color dark_5 #{$dark_5};

--- a/themes/yaru-sage-dark/_tweaks.scss
+++ b/themes/yaru-sage-dark/_tweaks.scss
@@ -1,0 +1,73 @@
+// Reducing the amount of the palette's background colors to two
+.sidebar {
+	background-color: $window_bg_color;
+}
+
+// Entries drown if drawn on widgets with $base_color
+// Fixing this at least for notebooks, since entries on tabs is a common pattern
+// Remove this when upstream makes entries have a light border in the dark theme
+@if $variant== "dark" {
+	notebook entry {
+			background-color: gtkmix($view_bg_color, black, 98%);
+	}
+}
+
+// Fix popover wiggling effect (see #2903)
+popover.menu {
+	check,
+	radio {
+			transition: none;
+	}
+}
+
+// Use our own palette for high and not empty levelbar
+levelbar {
+	> trough {
+			> block {
+					&.high,
+					&:not(.empty) {
+							background-color: $success_color;
+					}
+			}
+	}
+}
+
+// Green suggested buttons
+%button,
+button {
+	&.suggested-action {
+			color: $success_fg_color;
+
+			&,
+			&:checked {
+					&:not(.flat) {
+							background-color: $success_bg_color;
+					}
+			}
+	}
+
+	&.flat {
+			&.suggested-action {
+					color: $success_color;
+			}
+	}
+}
+
+splitbutton {
+	&.suggested-action {
+			> button, > menubutton > button {
+					color: $success_fg_color;
+	
+					&, &:checked {
+							background-color: $success_bg_color;
+					}
+			}
+	}
+}
+
+%button,
+button,
+%link,
+link {
+	font-weight: normal;
+}

--- a/themes/yaru-sage-dark/gtk-dark.scss
+++ b/themes/yaru-sage-dark/gtk-dark.scss
@@ -1,0 +1,13 @@
+// General guidelines:
+// - very unlikely you want to edit something else than _common.scss
+// - keep the number of defined colors to a minimum, use the color blending functions if
+//   you need a subtle shade
+// - if you need to inverse a color function use the @if directive to match for dark $variant
+
+$variant: 'dark';
+
+@import 'palette';
+@import 'defaults';
+@import 'functions';
+@import 'colors';
+@import 'tweaks';

--- a/themes/yaru-sage-dark/gtk.css
+++ b/themes/yaru-sage-dark/gtk.css
@@ -1,0 +1,121 @@
+@define-color yaru_accent_bg_color #657B69;
+@define-color blue_1 #75d3f4;
+@define-color blue_2 #47c4f1;
+@define-color blue_3 #19B6EE;
+@define-color blue_4 #007aa6;
+@define-color blue_5 #335280;
+@define-color green_1 #5AED70;
+@define-color green_2 #47D35C;
+@define-color green_3 #34B948;
+@define-color green_4 #219E34;
+@define-color green_5 #0e8420;
+@define-color yellow_1 #FCCD87;
+@define-color yellow_2 #FBC16A;
+@define-color yellow_3 #FBB44C;
+@define-color yellow_4 #FAA82F;
+@define-color yellow_5 #F99B11;
+@define-color orange_1 #F29879;
+@define-color orange_2 #F08763;
+@define-color orange_3 #ED764D;
+@define-color orange_4 #EB6536;
+@define-color orange_5 #E95420;
+@define-color red_1 #EA485C;
+@define-color red_2 #DE374C;
+@define-color red_3 #D3273B;
+@define-color red_4 #c7162b;
+@define-color red_5 #a91224;
+@define-color purple_1 #924D8B;
+@define-color purple_2 #762572;
+@define-color purple_3 #77216F;
+@define-color purple_4 #5E2750;
+@define-color purple_5 #2C001E;
+@define-color brown_1 #E1B289;
+@define-color brown_2 #C5976E;
+@define-color brown_3 #AA7B53;
+@define-color brown_4 #8E6038;
+@define-color brown_5 #72441D;
+@define-color light_1 #FFFFFF;
+@define-color light_2 #F7F7F7;
+@define-color light_3 #CCC;
+@define-color light_4 #AEA79F;
+@define-color light_5 #878787;
+@define-color dark_1 #666666;
+@define-color dark_2 #5D5D5D;
+@define-color dark_3 #3D3D3D;
+@define-color dark_4 #181818;
+@define-color dark_5 #000000;
+/* GTK NAMED COLORS
+   ----------------
+   use responsibly! */
+@define-color accent_bg_color @yaru_accent_bg_color;
+@define-color accent_fg_color @light_1;
+@define-color accent_color @yaru_accent_bg_color;
+@define-color destructive_bg_color @red_4;
+@define-color destructive_fg_color @light_1;
+@define-color destructive_color @red_4;
+@define-color success_bg_color @green_4;
+@define-color success_fg_color @light_1;
+@define-color success_color @green_4;
+@define-color warning_bg_color @yellow_5;
+@define-color warning_fg_color @light_1;
+@define-color warning_color @yellow_5;
+@define-color error_bg_color @red_4;
+@define-color error_fg_color @light_1;
+@define-color error_color @red_4;
+@define-color window_bg_color #2c2c2c;
+@define-color window_fg_color @light_2;
+@define-color view_bg_color #1e1e1e;
+@define-color view_fg_color #ffffff;
+@define-color headerbar_bg_color #303030;
+@define-color headerbar_fg_color white;
+@define-color headerbar_backdrop_color @window_bg_color;
+@define-color card_bg_color rgba(255, 255, 255, 0.08);
+@define-color card_fg_color white;
+@define-color popover_bg_color #383838;
+@define-color popover_fg_color white;
+.sidebar {
+  background-color: @window_bg_color;
+}
+
+notebook entry {
+  background-color: mix(@view_bg_color,black,0.02);
+}
+
+popover.menu check,
+popover.menu radio {
+  transition: none;
+}
+
+levelbar > trough > block.high, levelbar > trough > block:not(.empty) {
+  background-color: @success_color;
+}
+
+
+button.suggested-action {
+  color: @success_fg_color;
+}
+
+
+button.suggested-action:not(.flat),
+button.suggested-action:checked:not(.flat) {
+  background-color: @success_bg_color;
+}
+
+
+button.flat.suggested-action {
+  color: @success_color;
+}
+
+splitbutton.suggested-action > button, splitbutton.suggested-action > menubutton > button {
+  color: @success_fg_color;
+}
+
+splitbutton.suggested-action > button, splitbutton.suggested-action > button:checked, splitbutton.suggested-action > menubutton > button, splitbutton.suggested-action > menubutton > button:checked {
+  background-color: @success_bg_color;
+}
+
+
+button,
+link {
+  font-weight: normal;
+}

--- a/themes/yaru-sage-dark/gtk.scss
+++ b/themes/yaru-sage-dark/gtk.scss
@@ -1,0 +1,14 @@
+// General guidelines:
+// - very unlikely you want to edit something else than _common.scss
+// - keep the number of defined colors to a minimum, use the color blending functions if
+//   you need a subtle shade
+// - if you need to inverse a color function use the @if directive to match for dark $variant
+
+$variant: 'light';
+
+@import 'palette';
+@import 'defaults';
+@import 'functions';
+@import 'colors';
+@import 'tweaks';
+

--- a/themes/yaru-sage-dark/parse-sass.sh
+++ b/themes/yaru-sage-dark/parse-sass.sh
@@ -1,0 +1,12 @@
+#! /bin/bash
+
+if [ ! "$(which sassc 2> /dev/null)" ]; then
+   echo sassc needs to be installed to generate the css.
+   exit 1
+fi
+
+SASSC_OPT="-M -t expanded"
+
+echo Generating the css...
+
+sassc $SASSC_OPT gtk-dark.scss gtk.css

--- a/themes/yaru-sage/_colors.scss
+++ b/themes/yaru-sage/_colors.scss
@@ -1,0 +1,35 @@
+$accent_bg_color: gtkcolor(accent_bg_color);
+$accent_fg_color: gtkcolor(accent_fg_color);
+$accent_color: gtkcolor(accent_color);
+
+$destructive_bg_color: gtkcolor(destructive_bg_color);
+$destructive_fg_color: gtkcolor(destructive_fg_color);
+$destructive_color: gtkcolor(destructive_color);
+
+$success_bg_color: gtkcolor(success_bg_color);
+$success_fg_color: gtkcolor(success_fg_color);
+$success_color: gtkcolor(success_color);
+
+$warning_bg_color: gtkcolor(warning_bg_color);
+$warning_fg_color: gtkcolor(warning_fg_color);
+$warning_color: gtkcolor(warning_color);
+
+$error_bg_color: gtkcolor(error_bg_color);
+$error_fg_color: gtkcolor(error_fg_color);
+$error_color: gtkcolor(error_color);
+
+$window_bg_color: gtkcolor(window_bg_color);
+$window_fg_color: gtkcolor(window_fg_color);
+
+$view_bg_color: gtkcolor(view_bg_color);
+$view_fg_color: gtkcolor(view_fg_color);
+
+$headerbar_bg_color: gtkcolor(headerbar_bg_color);
+$headerbar_fg_color: gtkcolor(headerbar_fg_color);
+$headerbar_backdrop_color: gtkcolor(headerbar_backdrop_color);
+
+$card_bg_color: gtkcolor(card_bg_color);
+$card_fg_color: gtkcolor(card_fg_color);
+
+$popover_bg_color: gtkcolor(popover_bg_color);
+$popover_fg_color: gtkcolor(popover_fg_color);

--- a/themes/yaru-sage/_defaults.scss
+++ b/themes/yaru-sage/_defaults.scss
@@ -1,0 +1,53 @@
+/* GTK NAMED COLORS
+   ----------------
+   use responsibly! */
+
+// Sass thinks we're using the colors in the variables as strings and may shoot
+// warning, it's innocuous and can be defeated by using #{$var}.
+
+// These are the colors apps are can override. We define the defaults here and
+// define variables for them in _colors.scss
+
+// The main accent color and the matching text value
+@define-color accent_bg_color @yaru_accent_bg_color;
+@define-color accent_fg_color @light_1;
+@define-color accent_color @yaru_accent_bg_color;
+
+// destructive-action buttons
+@define-color destructive_bg_color @red_4;
+@define-color destructive_fg_color @light_1;
+@define-color destructive_color @red_4;
+
+// Levelbars, entries, labels and infobars. These don't need text colors
+@define-color success_bg_color @green_4;
+@define-color success_fg_color @light_1;
+@define-color success_color @green_4;
+
+@define-color warning_bg_color @yellow_5;
+@define-color warning_fg_color @light_1;
+@define-color warning_color @yellow_5;
+
+@define-color error_bg_color @red_4;
+@define-color error_fg_color @light_1;
+@define-color error_color @red_4;
+
+// Window
+@define-color window_bg_color #{if($variant == 'light', #fafafa, lighten(#181818, 8%))};
+@define-color window_fg_color #{if($variant=='light', '@dark_3', '@light_2')};
+
+// Views - e.g. text view or tree view
+@define-color view_bg_color #{if($variant == 'light', #ffffff, #1e1e1e)};
+@define-color view_fg_color #{if($variant == 'light', #000000, #ffffff)};
+
+// Header bar, search bar, tab bar
+@define-color headerbar_bg_color #{if($variant == 'light', #ebebeb, #303030)};
+@define-color headerbar_fg_color #{if($variant == 'light', transparentize(black, .2), white)};
+@define-color headerbar_backdrop_color @window_bg_color;
+
+// Cards, boxed lists
+@define-color card_bg_color #{if($variant == 'light', #ffffff, transparentize(white, .92))};
+@define-color card_fg_color #{if($variant == 'light', transparentize(black, .2), white)};
+
+// Popovers
+@define-color popover_bg_color #{if($variant == 'light', #ffffff, #383838)};
+@define-color popover_fg_color #{if($variant == 'light', transparentize(black, .2), white)};

--- a/themes/yaru-sage/_functions.scss
+++ b/themes/yaru-sage/_functions.scss
@@ -1,0 +1,16 @@
+@function gtkalpha($c,$a) {
+  @return unquote("alpha(#{$c},#{$a})");
+}
+
+@function gtkmix($c1,$c2,$r) {
+  $ratio: 1 -  $r / 100%; // match SCSS mix()
+  @return unquote("mix(#{$c1},#{$c2},#{$ratio})");
+}
+
+@function gtkshade($c,$s) {
+  @return unquote("shade(#{$c},#{$s})");
+}
+
+@function gtkcolor($c) {
+  @return unquote("@#{$c}");
+}

--- a/themes/yaru-sage/_palette.scss
+++ b/themes/yaru-sage/_palette.scss
@@ -1,0 +1,110 @@
+$blue_1: #75d3f4;
+$blue_2: #47c4f1;
+$blue_3: #19B6EE; // Yaru blue
+$blue_4: #007aa6; // Yaru linkblue
+$blue_5: #335280; // Yaru darkblue
+$green_1: #5AED70;
+$green_2: #47D35C;
+$green_3: #34B948;
+$green_4: #219E34;
+$green_5: #0e8420; // Yaru green
+$yellow_1: #FCCD87;
+$yellow_2: #FBC16A;
+$yellow_3: #FBB44C;
+$yellow_4: #FAA82F;
+$yellow_5: #F99B11; // Yaru yellow
+$orange_1: #F29879;
+$orange_2: #F08763;
+$orange_3: #ED764D;
+$orange_4: #EB6536;
+$orange_5: #E95420; // Yaru orange
+$red_1: #EA485C;
+$red_2: #DE374C;
+$red_3: #D3273B;
+$red_4: #c7162b; // Yaru red
+$red_5: #a91224;
+$purple_1: #924D8B; // Yaru aubergine
+$purple_2: #762572; // Yaru purple
+$purple_3: #77216F; // Yaru light aubergine
+$purple_4: #5E2750; // Yaru mid aubergine
+$purple_5: #2C001E; // Yaru dark aubergine
+$brown_1: #E1B289;
+$brown_2: #C5976E;
+$brown_3: #AA7B53;
+$brown_4: #8E6038;
+$brown_5: #72441D;
+$light_1: #FFFFFF;
+$light_2: #F7F7F7; // Yaru porcelain
+$light_3: #CCC; // Yaru silk
+$light_4: #AEA79F; // Yaru warm gray
+$light_5: #878787; // Yaru ash
+$dark_1: #666666; // Yaru graphite
+$dark_2: #5D5D5D; // Yaru slate
+$dark_3: #3D3D3D; // Yaru inkstone
+$dark_4: #181818; // Yaru jet
+$dark_5: #000000;
+
+// Ubuntu accent colors
+$default: $orange_5;
+$bark: #787859;
+$sage: #657B69;
+$olive: #4B8501;
+$viridian: #03875B;
+$prussiangreen: #308280;
+$blue: #0073E5;
+$purple: #7764D8;
+$magenta: #B34CB3;
+$red: #DA3450;
+
+$yaru_accent_bg_color: $sage !default;
+@define-color yaru_accent_bg_color #{$yaru_accent_bg_color};
+
+
+// Sass thinks we're using the colors in the variables as strings and may shoot
+// warning, it's innocuous and can be defeated by using #{$var}.
+
+@define-color blue_1 #{$blue_1};
+@define-color blue_2 #{$blue_2};
+@define-color blue_3 #{$blue_3};
+@define-color blue_4 #{$blue_4};
+@define-color blue_5 #{$blue_5};
+@define-color green_1 #{$green_1};
+@define-color green_2 #{$green_2};
+@define-color green_3 #{$green_3};
+@define-color green_4 #{$green_4};
+@define-color green_5 #{$green_5};
+@define-color yellow_1 #{$yellow_1};
+@define-color yellow_2 #{$yellow_2};
+@define-color yellow_3 #{$yellow_3};
+@define-color yellow_4 #{$yellow_4};
+@define-color yellow_5 #{$yellow_5};
+@define-color orange_1 #{$orange_1};
+@define-color orange_2 #{$orange_2};
+@define-color orange_3 #{$orange_3};
+@define-color orange_4 #{$orange_4};
+@define-color orange_5 #{$orange_5};
+@define-color red_1 #{$red_1};
+@define-color red_2 #{$red_2};
+@define-color red_3 #{$red_3};
+@define-color red_4 #{$red_4};
+@define-color red_5 #{$red_5};
+@define-color purple_1 #{$purple_1};
+@define-color purple_2 #{$purple_2};
+@define-color purple_3 #{$purple_3};
+@define-color purple_4 #{$purple_4};
+@define-color purple_5 #{$purple_5};
+@define-color brown_1 #{$brown_1};
+@define-color brown_2 #{$brown_2};
+@define-color brown_3 #{$brown_3};
+@define-color brown_4 #{$brown_4};
+@define-color brown_5 #{$brown_5};
+@define-color light_1 #{$light_1};
+@define-color light_2 #{$light_2};
+@define-color light_3 #{$light_3};
+@define-color light_4 #{$light_4};
+@define-color light_5 #{$light_5};
+@define-color dark_1 #{$dark_1};
+@define-color dark_2 #{$dark_2};
+@define-color dark_3 #{$dark_3};
+@define-color dark_4 #{$dark_4};
+@define-color dark_5 #{$dark_5};

--- a/themes/yaru-sage/_tweaks.scss
+++ b/themes/yaru-sage/_tweaks.scss
@@ -1,0 +1,73 @@
+// Reducing the amount of the palette's background colors to two
+.sidebar {
+	background-color: $window_bg_color;
+}
+
+// Entries drown if drawn on widgets with $base_color
+// Fixing this at least for notebooks, since entries on tabs is a common pattern
+// Remove this when upstream makes entries have a light border in the dark theme
+@if $variant== "dark" {
+	notebook entry {
+			background-color: gtkmix($view_bg_color, black, 98%);
+	}
+}
+
+// Fix popover wiggling effect (see #2903)
+popover.menu {
+	check,
+	radio {
+			transition: none;
+	}
+}
+
+// Use our own palette for high and not empty levelbar
+levelbar {
+	> trough {
+			> block {
+					&.high,
+					&:not(.empty) {
+							background-color: $success_color;
+					}
+			}
+	}
+}
+
+// Green suggested buttons
+%button,
+button {
+	&.suggested-action {
+			color: $success_fg_color;
+
+			&,
+			&:checked {
+					&:not(.flat) {
+							background-color: $success_bg_color;
+					}
+			}
+	}
+
+	&.flat {
+			&.suggested-action {
+					color: $success_color;
+			}
+	}
+}
+
+splitbutton {
+	&.suggested-action {
+			> button, > menubutton > button {
+					color: $success_fg_color;
+	
+					&, &:checked {
+							background-color: $success_bg_color;
+					}
+			}
+	}
+}
+
+%button,
+button,
+%link,
+link {
+	font-weight: normal;
+}

--- a/themes/yaru-sage/gtk-dark.scss
+++ b/themes/yaru-sage/gtk-dark.scss
@@ -1,0 +1,13 @@
+// General guidelines:
+// - very unlikely you want to edit something else than _common.scss
+// - keep the number of defined colors to a minimum, use the color blending functions if
+//   you need a subtle shade
+// - if you need to inverse a color function use the @if directive to match for dark $variant
+
+$variant: 'dark';
+
+@import 'palette';
+@import 'defaults';
+@import 'functions';
+@import 'colors';
+@import 'tweaks';

--- a/themes/yaru-sage/gtk.css
+++ b/themes/yaru-sage/gtk.css
@@ -1,0 +1,117 @@
+@define-color yaru_accent_bg_color #657B69;
+@define-color blue_1 #75d3f4;
+@define-color blue_2 #47c4f1;
+@define-color blue_3 #19B6EE;
+@define-color blue_4 #007aa6;
+@define-color blue_5 #335280;
+@define-color green_1 #5AED70;
+@define-color green_2 #47D35C;
+@define-color green_3 #34B948;
+@define-color green_4 #219E34;
+@define-color green_5 #0e8420;
+@define-color yellow_1 #FCCD87;
+@define-color yellow_2 #FBC16A;
+@define-color yellow_3 #FBB44C;
+@define-color yellow_4 #FAA82F;
+@define-color yellow_5 #F99B11;
+@define-color orange_1 #F29879;
+@define-color orange_2 #F08763;
+@define-color orange_3 #ED764D;
+@define-color orange_4 #EB6536;
+@define-color orange_5 #E95420;
+@define-color red_1 #EA485C;
+@define-color red_2 #DE374C;
+@define-color red_3 #D3273B;
+@define-color red_4 #c7162b;
+@define-color red_5 #a91224;
+@define-color purple_1 #924D8B;
+@define-color purple_2 #762572;
+@define-color purple_3 #77216F;
+@define-color purple_4 #5E2750;
+@define-color purple_5 #2C001E;
+@define-color brown_1 #E1B289;
+@define-color brown_2 #C5976E;
+@define-color brown_3 #AA7B53;
+@define-color brown_4 #8E6038;
+@define-color brown_5 #72441D;
+@define-color light_1 #FFFFFF;
+@define-color light_2 #F7F7F7;
+@define-color light_3 #CCC;
+@define-color light_4 #AEA79F;
+@define-color light_5 #878787;
+@define-color dark_1 #666666;
+@define-color dark_2 #5D5D5D;
+@define-color dark_3 #3D3D3D;
+@define-color dark_4 #181818;
+@define-color dark_5 #000000;
+/* GTK NAMED COLORS
+   ----------------
+   use responsibly! */
+@define-color accent_bg_color @yaru_accent_bg_color;
+@define-color accent_fg_color @light_1;
+@define-color accent_color @yaru_accent_bg_color;
+@define-color destructive_bg_color @red_4;
+@define-color destructive_fg_color @light_1;
+@define-color destructive_color @red_4;
+@define-color success_bg_color @green_4;
+@define-color success_fg_color @light_1;
+@define-color success_color @green_4;
+@define-color warning_bg_color @yellow_5;
+@define-color warning_fg_color @light_1;
+@define-color warning_color @yellow_5;
+@define-color error_bg_color @red_4;
+@define-color error_fg_color @light_1;
+@define-color error_color @red_4;
+@define-color window_bg_color #fafafa;
+@define-color window_fg_color @dark_3;
+@define-color view_bg_color #ffffff;
+@define-color view_fg_color #000000;
+@define-color headerbar_bg_color #ebebeb;
+@define-color headerbar_fg_color rgba(0, 0, 0, 0.8);
+@define-color headerbar_backdrop_color @window_bg_color;
+@define-color card_bg_color #ffffff;
+@define-color card_fg_color rgba(0, 0, 0, 0.8);
+@define-color popover_bg_color #ffffff;
+@define-color popover_fg_color rgba(0, 0, 0, 0.8);
+.sidebar {
+  background-color: @window_bg_color;
+}
+
+popover.menu check,
+popover.menu radio {
+  transition: none;
+}
+
+levelbar > trough > block.high, levelbar > trough > block:not(.empty) {
+  background-color: @success_color;
+}
+
+
+button.suggested-action {
+  color: @success_fg_color;
+}
+
+
+button.suggested-action:not(.flat),
+button.suggested-action:checked:not(.flat) {
+  background-color: @success_bg_color;
+}
+
+
+button.flat.suggested-action {
+  color: @success_color;
+}
+
+splitbutton.suggested-action > button, splitbutton.suggested-action > menubutton > button {
+  color: @success_fg_color;
+}
+
+splitbutton.suggested-action > button, splitbutton.suggested-action > button:checked, splitbutton.suggested-action > menubutton > button, splitbutton.suggested-action > menubutton > button:checked {
+  background-color: @success_bg_color;
+}
+
+
+button,
+link {
+  font-weight: normal;
+}

--- a/themes/yaru-sage/gtk.scss
+++ b/themes/yaru-sage/gtk.scss
@@ -1,0 +1,14 @@
+// General guidelines:
+// - very unlikely you want to edit something else than _common.scss
+// - keep the number of defined colors to a minimum, use the color blending functions if
+//   you need a subtle shade
+// - if you need to inverse a color function use the @if directive to match for dark $variant
+
+$variant: 'light';
+
+@import 'palette';
+@import 'defaults';
+@import 'functions';
+@import 'colors';
+@import 'tweaks';
+

--- a/themes/yaru-sage/parse-sass.sh
+++ b/themes/yaru-sage/parse-sass.sh
@@ -1,0 +1,12 @@
+#! /bin/bash
+
+if [ ! "$(which sassc 2> /dev/null)" ]; then
+   echo sassc needs to be installed to generate the css.
+   exit 1
+fi
+
+SASSC_OPT="-M -t expanded"
+
+echo Generating the css...
+
+sassc $SASSC_OPT gtk.scss gtk.css

--- a/themes/yaru-viridian-dark/_colors.scss
+++ b/themes/yaru-viridian-dark/_colors.scss
@@ -1,0 +1,35 @@
+$accent_bg_color: gtkcolor(accent_bg_color);
+$accent_fg_color: gtkcolor(accent_fg_color);
+$accent_color: gtkcolor(accent_color);
+
+$destructive_bg_color: gtkcolor(destructive_bg_color);
+$destructive_fg_color: gtkcolor(destructive_fg_color);
+$destructive_color: gtkcolor(destructive_color);
+
+$success_bg_color: gtkcolor(success_bg_color);
+$success_fg_color: gtkcolor(success_fg_color);
+$success_color: gtkcolor(success_color);
+
+$warning_bg_color: gtkcolor(warning_bg_color);
+$warning_fg_color: gtkcolor(warning_fg_color);
+$warning_color: gtkcolor(warning_color);
+
+$error_bg_color: gtkcolor(error_bg_color);
+$error_fg_color: gtkcolor(error_fg_color);
+$error_color: gtkcolor(error_color);
+
+$window_bg_color: gtkcolor(window_bg_color);
+$window_fg_color: gtkcolor(window_fg_color);
+
+$view_bg_color: gtkcolor(view_bg_color);
+$view_fg_color: gtkcolor(view_fg_color);
+
+$headerbar_bg_color: gtkcolor(headerbar_bg_color);
+$headerbar_fg_color: gtkcolor(headerbar_fg_color);
+$headerbar_backdrop_color: gtkcolor(headerbar_backdrop_color);
+
+$card_bg_color: gtkcolor(card_bg_color);
+$card_fg_color: gtkcolor(card_fg_color);
+
+$popover_bg_color: gtkcolor(popover_bg_color);
+$popover_fg_color: gtkcolor(popover_fg_color);

--- a/themes/yaru-viridian-dark/_defaults.scss
+++ b/themes/yaru-viridian-dark/_defaults.scss
@@ -1,0 +1,53 @@
+/* GTK NAMED COLORS
+   ----------------
+   use responsibly! */
+
+// Sass thinks we're using the colors in the variables as strings and may shoot
+// warning, it's innocuous and can be defeated by using #{$var}.
+
+// These are the colors apps are can override. We define the defaults here and
+// define variables for them in _colors.scss
+
+// The main accent color and the matching text value
+@define-color accent_bg_color @yaru_accent_bg_color;
+@define-color accent_fg_color @light_1;
+@define-color accent_color @yaru_accent_bg_color;
+
+// destructive-action buttons
+@define-color destructive_bg_color @red_4;
+@define-color destructive_fg_color @light_1;
+@define-color destructive_color @red_4;
+
+// Levelbars, entries, labels and infobars. These don't need text colors
+@define-color success_bg_color @green_4;
+@define-color success_fg_color @light_1;
+@define-color success_color @green_4;
+
+@define-color warning_bg_color @yellow_5;
+@define-color warning_fg_color @light_1;
+@define-color warning_color @yellow_5;
+
+@define-color error_bg_color @red_4;
+@define-color error_fg_color @light_1;
+@define-color error_color @red_4;
+
+// Window
+@define-color window_bg_color #{if($variant == 'light', #fafafa, lighten(#181818, 8%))};
+@define-color window_fg_color #{if($variant=='light', '@dark_3', '@light_2')};
+
+// Views - e.g. text view or tree view
+@define-color view_bg_color #{if($variant == 'light', #ffffff, #1e1e1e)};
+@define-color view_fg_color #{if($variant == 'light', #000000, #ffffff)};
+
+// Header bar, search bar, tab bar
+@define-color headerbar_bg_color #{if($variant == 'light', #ebebeb, #303030)};
+@define-color headerbar_fg_color #{if($variant == 'light', transparentize(black, .2), white)};
+@define-color headerbar_backdrop_color @window_bg_color;
+
+// Cards, boxed lists
+@define-color card_bg_color #{if($variant == 'light', #ffffff, transparentize(white, .92))};
+@define-color card_fg_color #{if($variant == 'light', transparentize(black, .2), white)};
+
+// Popovers
+@define-color popover_bg_color #{if($variant == 'light', #ffffff, #383838)};
+@define-color popover_fg_color #{if($variant == 'light', transparentize(black, .2), white)};

--- a/themes/yaru-viridian-dark/_functions.scss
+++ b/themes/yaru-viridian-dark/_functions.scss
@@ -1,0 +1,16 @@
+@function gtkalpha($c,$a) {
+  @return unquote("alpha(#{$c},#{$a})");
+}
+
+@function gtkmix($c1,$c2,$r) {
+  $ratio: 1 -  $r / 100%; // match SCSS mix()
+  @return unquote("mix(#{$c1},#{$c2},#{$ratio})");
+}
+
+@function gtkshade($c,$s) {
+  @return unquote("shade(#{$c},#{$s})");
+}
+
+@function gtkcolor($c) {
+  @return unquote("@#{$c}");
+}

--- a/themes/yaru-viridian-dark/_palette.scss
+++ b/themes/yaru-viridian-dark/_palette.scss
@@ -1,0 +1,110 @@
+$blue_1: #75d3f4;
+$blue_2: #47c4f1;
+$blue_3: #19B6EE; // Yaru blue
+$blue_4: #007aa6; // Yaru linkblue
+$blue_5: #335280; // Yaru darkblue
+$green_1: #5AED70;
+$green_2: #47D35C;
+$green_3: #34B948;
+$green_4: #219E34;
+$green_5: #0e8420; // Yaru green
+$yellow_1: #FCCD87;
+$yellow_2: #FBC16A;
+$yellow_3: #FBB44C;
+$yellow_4: #FAA82F;
+$yellow_5: #F99B11; // Yaru yellow
+$orange_1: #F29879;
+$orange_2: #F08763;
+$orange_3: #ED764D;
+$orange_4: #EB6536;
+$orange_5: #E95420; // Yaru orange
+$red_1: #EA485C;
+$red_2: #DE374C;
+$red_3: #D3273B;
+$red_4: #c7162b; // Yaru red
+$red_5: #a91224;
+$purple_1: #924D8B; // Yaru aubergine
+$purple_2: #762572; // Yaru purple
+$purple_3: #77216F; // Yaru light aubergine
+$purple_4: #5E2750; // Yaru mid aubergine
+$purple_5: #2C001E; // Yaru dark aubergine
+$brown_1: #E1B289;
+$brown_2: #C5976E;
+$brown_3: #AA7B53;
+$brown_4: #8E6038;
+$brown_5: #72441D;
+$light_1: #FFFFFF;
+$light_2: #F7F7F7; // Yaru porcelain
+$light_3: #CCC; // Yaru silk
+$light_4: #AEA79F; // Yaru warm gray
+$light_5: #878787; // Yaru ash
+$dark_1: #666666; // Yaru graphite
+$dark_2: #5D5D5D; // Yaru slate
+$dark_3: #3D3D3D; // Yaru inkstone
+$dark_4: #181818; // Yaru jet
+$dark_5: #000000;
+
+// Ubuntu accent colors
+$default: $orange_5;
+$bark: #787859;
+$sage: #657B69;
+$olive: #4B8501;
+$viridian: #03875B;
+$prussiangreen: #308280;
+$blue: #0073E5;
+$purple: #7764D8;
+$magenta: #B34CB3;
+$red: #DA3450;
+
+$yaru_accent_bg_color: $viridian !default;
+@define-color yaru_accent_bg_color #{$yaru_accent_bg_color};
+
+
+// Sass thinks we're using the colors in the variables as strings and may shoot
+// warning, it's innocuous and can be defeated by using #{$var}.
+
+@define-color blue_1 #{$blue_1};
+@define-color blue_2 #{$blue_2};
+@define-color blue_3 #{$blue_3};
+@define-color blue_4 #{$blue_4};
+@define-color blue_5 #{$blue_5};
+@define-color green_1 #{$green_1};
+@define-color green_2 #{$green_2};
+@define-color green_3 #{$green_3};
+@define-color green_4 #{$green_4};
+@define-color green_5 #{$green_5};
+@define-color yellow_1 #{$yellow_1};
+@define-color yellow_2 #{$yellow_2};
+@define-color yellow_3 #{$yellow_3};
+@define-color yellow_4 #{$yellow_4};
+@define-color yellow_5 #{$yellow_5};
+@define-color orange_1 #{$orange_1};
+@define-color orange_2 #{$orange_2};
+@define-color orange_3 #{$orange_3};
+@define-color orange_4 #{$orange_4};
+@define-color orange_5 #{$orange_5};
+@define-color red_1 #{$red_1};
+@define-color red_2 #{$red_2};
+@define-color red_3 #{$red_3};
+@define-color red_4 #{$red_4};
+@define-color red_5 #{$red_5};
+@define-color purple_1 #{$purple_1};
+@define-color purple_2 #{$purple_2};
+@define-color purple_3 #{$purple_3};
+@define-color purple_4 #{$purple_4};
+@define-color purple_5 #{$purple_5};
+@define-color brown_1 #{$brown_1};
+@define-color brown_2 #{$brown_2};
+@define-color brown_3 #{$brown_3};
+@define-color brown_4 #{$brown_4};
+@define-color brown_5 #{$brown_5};
+@define-color light_1 #{$light_1};
+@define-color light_2 #{$light_2};
+@define-color light_3 #{$light_3};
+@define-color light_4 #{$light_4};
+@define-color light_5 #{$light_5};
+@define-color dark_1 #{$dark_1};
+@define-color dark_2 #{$dark_2};
+@define-color dark_3 #{$dark_3};
+@define-color dark_4 #{$dark_4};
+@define-color dark_5 #{$dark_5};

--- a/themes/yaru-viridian-dark/_tweaks.scss
+++ b/themes/yaru-viridian-dark/_tweaks.scss
@@ -1,0 +1,73 @@
+// Reducing the amount of the palette's background colors to two
+.sidebar {
+	background-color: $window_bg_color;
+}
+
+// Entries drown if drawn on widgets with $base_color
+// Fixing this at least for notebooks, since entries on tabs is a common pattern
+// Remove this when upstream makes entries have a light border in the dark theme
+@if $variant== "dark" {
+	notebook entry {
+			background-color: gtkmix($view_bg_color, black, 98%);
+	}
+}
+
+// Fix popover wiggling effect (see #2903)
+popover.menu {
+	check,
+	radio {
+			transition: none;
+	}
+}
+
+// Use our own palette for high and not empty levelbar
+levelbar {
+	> trough {
+			> block {
+					&.high,
+					&:not(.empty) {
+							background-color: $success_color;
+					}
+			}
+	}
+}
+
+// Green suggested buttons
+%button,
+button {
+	&.suggested-action {
+			color: $success_fg_color;
+
+			&,
+			&:checked {
+					&:not(.flat) {
+							background-color: $success_bg_color;
+					}
+			}
+	}
+
+	&.flat {
+			&.suggested-action {
+					color: $success_color;
+			}
+	}
+}
+
+splitbutton {
+	&.suggested-action {
+			> button, > menubutton > button {
+					color: $success_fg_color;
+	
+					&, &:checked {
+							background-color: $success_bg_color;
+					}
+			}
+	}
+}
+
+%button,
+button,
+%link,
+link {
+	font-weight: normal;
+}

--- a/themes/yaru-viridian-dark/gtk-dark.scss
+++ b/themes/yaru-viridian-dark/gtk-dark.scss
@@ -1,0 +1,13 @@
+// General guidelines:
+// - very unlikely you want to edit something else than _common.scss
+// - keep the number of defined colors to a minimum, use the color blending functions if
+//   you need a subtle shade
+// - if you need to inverse a color function use the @if directive to match for dark $variant
+
+$variant: 'dark';
+
+@import 'palette';
+@import 'defaults';
+@import 'functions';
+@import 'colors';
+@import 'tweaks';

--- a/themes/yaru-viridian-dark/gtk.css
+++ b/themes/yaru-viridian-dark/gtk.css
@@ -1,0 +1,121 @@
+@define-color yaru_accent_bg_color #03875B;
+@define-color blue_1 #75d3f4;
+@define-color blue_2 #47c4f1;
+@define-color blue_3 #19B6EE;
+@define-color blue_4 #007aa6;
+@define-color blue_5 #335280;
+@define-color green_1 #5AED70;
+@define-color green_2 #47D35C;
+@define-color green_3 #34B948;
+@define-color green_4 #219E34;
+@define-color green_5 #0e8420;
+@define-color yellow_1 #FCCD87;
+@define-color yellow_2 #FBC16A;
+@define-color yellow_3 #FBB44C;
+@define-color yellow_4 #FAA82F;
+@define-color yellow_5 #F99B11;
+@define-color orange_1 #F29879;
+@define-color orange_2 #F08763;
+@define-color orange_3 #ED764D;
+@define-color orange_4 #EB6536;
+@define-color orange_5 #E95420;
+@define-color red_1 #EA485C;
+@define-color red_2 #DE374C;
+@define-color red_3 #D3273B;
+@define-color red_4 #c7162b;
+@define-color red_5 #a91224;
+@define-color purple_1 #924D8B;
+@define-color purple_2 #762572;
+@define-color purple_3 #77216F;
+@define-color purple_4 #5E2750;
+@define-color purple_5 #2C001E;
+@define-color brown_1 #E1B289;
+@define-color brown_2 #C5976E;
+@define-color brown_3 #AA7B53;
+@define-color brown_4 #8E6038;
+@define-color brown_5 #72441D;
+@define-color light_1 #FFFFFF;
+@define-color light_2 #F7F7F7;
+@define-color light_3 #CCC;
+@define-color light_4 #AEA79F;
+@define-color light_5 #878787;
+@define-color dark_1 #666666;
+@define-color dark_2 #5D5D5D;
+@define-color dark_3 #3D3D3D;
+@define-color dark_4 #181818;
+@define-color dark_5 #000000;
+/* GTK NAMED COLORS
+   ----------------
+   use responsibly! */
+@define-color accent_bg_color @yaru_accent_bg_color;
+@define-color accent_fg_color @light_1;
+@define-color accent_color @yaru_accent_bg_color;
+@define-color destructive_bg_color @red_4;
+@define-color destructive_fg_color @light_1;
+@define-color destructive_color @red_4;
+@define-color success_bg_color @green_4;
+@define-color success_fg_color @light_1;
+@define-color success_color @green_4;
+@define-color warning_bg_color @yellow_5;
+@define-color warning_fg_color @light_1;
+@define-color warning_color @yellow_5;
+@define-color error_bg_color @red_4;
+@define-color error_fg_color @light_1;
+@define-color error_color @red_4;
+@define-color window_bg_color #2c2c2c;
+@define-color window_fg_color @light_2;
+@define-color view_bg_color #1e1e1e;
+@define-color view_fg_color #ffffff;
+@define-color headerbar_bg_color #303030;
+@define-color headerbar_fg_color white;
+@define-color headerbar_backdrop_color @window_bg_color;
+@define-color card_bg_color rgba(255, 255, 255, 0.08);
+@define-color card_fg_color white;
+@define-color popover_bg_color #383838;
+@define-color popover_fg_color white;
+.sidebar {
+  background-color: @window_bg_color;
+}
+
+notebook entry {
+  background-color: mix(@view_bg_color,black,0.02);
+}
+
+popover.menu check,
+popover.menu radio {
+  transition: none;
+}
+
+levelbar > trough > block.high, levelbar > trough > block:not(.empty) {
+  background-color: @success_color;
+}
+
+
+button.suggested-action {
+  color: @success_fg_color;
+}
+
+
+button.suggested-action:not(.flat),
+button.suggested-action:checked:not(.flat) {
+  background-color: @success_bg_color;
+}
+
+
+button.flat.suggested-action {
+  color: @success_color;
+}
+
+splitbutton.suggested-action > button, splitbutton.suggested-action > menubutton > button {
+  color: @success_fg_color;
+}
+
+splitbutton.suggested-action > button, splitbutton.suggested-action > button:checked, splitbutton.suggested-action > menubutton > button, splitbutton.suggested-action > menubutton > button:checked {
+  background-color: @success_bg_color;
+}
+
+
+button,
+link {
+  font-weight: normal;
+}

--- a/themes/yaru-viridian-dark/gtk.scss
+++ b/themes/yaru-viridian-dark/gtk.scss
@@ -1,0 +1,14 @@
+// General guidelines:
+// - very unlikely you want to edit something else than _common.scss
+// - keep the number of defined colors to a minimum, use the color blending functions if
+//   you need a subtle shade
+// - if you need to inverse a color function use the @if directive to match for dark $variant
+
+$variant: 'light';
+
+@import 'palette';
+@import 'defaults';
+@import 'functions';
+@import 'colors';
+@import 'tweaks';
+

--- a/themes/yaru-viridian-dark/parse-sass.sh
+++ b/themes/yaru-viridian-dark/parse-sass.sh
@@ -1,0 +1,12 @@
+#! /bin/bash
+
+if [ ! "$(which sassc 2> /dev/null)" ]; then
+   echo sassc needs to be installed to generate the css.
+   exit 1
+fi
+
+SASSC_OPT="-M -t expanded"
+
+echo Generating the css...
+
+sassc $SASSC_OPT gtk-dark.scss gtk.css

--- a/themes/yaru-viridian/_colors.scss
+++ b/themes/yaru-viridian/_colors.scss
@@ -1,0 +1,35 @@
+$accent_bg_color: gtkcolor(accent_bg_color);
+$accent_fg_color: gtkcolor(accent_fg_color);
+$accent_color: gtkcolor(accent_color);
+
+$destructive_bg_color: gtkcolor(destructive_bg_color);
+$destructive_fg_color: gtkcolor(destructive_fg_color);
+$destructive_color: gtkcolor(destructive_color);
+
+$success_bg_color: gtkcolor(success_bg_color);
+$success_fg_color: gtkcolor(success_fg_color);
+$success_color: gtkcolor(success_color);
+
+$warning_bg_color: gtkcolor(warning_bg_color);
+$warning_fg_color: gtkcolor(warning_fg_color);
+$warning_color: gtkcolor(warning_color);
+
+$error_bg_color: gtkcolor(error_bg_color);
+$error_fg_color: gtkcolor(error_fg_color);
+$error_color: gtkcolor(error_color);
+
+$window_bg_color: gtkcolor(window_bg_color);
+$window_fg_color: gtkcolor(window_fg_color);
+
+$view_bg_color: gtkcolor(view_bg_color);
+$view_fg_color: gtkcolor(view_fg_color);
+
+$headerbar_bg_color: gtkcolor(headerbar_bg_color);
+$headerbar_fg_color: gtkcolor(headerbar_fg_color);
+$headerbar_backdrop_color: gtkcolor(headerbar_backdrop_color);
+
+$card_bg_color: gtkcolor(card_bg_color);
+$card_fg_color: gtkcolor(card_fg_color);
+
+$popover_bg_color: gtkcolor(popover_bg_color);
+$popover_fg_color: gtkcolor(popover_fg_color);

--- a/themes/yaru-viridian/_defaults.scss
+++ b/themes/yaru-viridian/_defaults.scss
@@ -1,0 +1,53 @@
+/* GTK NAMED COLORS
+   ----------------
+   use responsibly! */
+
+// Sass thinks we're using the colors in the variables as strings and may shoot
+// warning, it's innocuous and can be defeated by using #{$var}.
+
+// These are the colors apps are can override. We define the defaults here and
+// define variables for them in _colors.scss
+
+// The main accent color and the matching text value
+@define-color accent_bg_color @yaru_accent_bg_color;
+@define-color accent_fg_color @light_1;
+@define-color accent_color @yaru_accent_bg_color;
+
+// destructive-action buttons
+@define-color destructive_bg_color @red_4;
+@define-color destructive_fg_color @light_1;
+@define-color destructive_color @red_4;
+
+// Levelbars, entries, labels and infobars. These don't need text colors
+@define-color success_bg_color @green_4;
+@define-color success_fg_color @light_1;
+@define-color success_color @green_4;
+
+@define-color warning_bg_color @yellow_5;
+@define-color warning_fg_color @light_1;
+@define-color warning_color @yellow_5;
+
+@define-color error_bg_color @red_4;
+@define-color error_fg_color @light_1;
+@define-color error_color @red_4;
+
+// Window
+@define-color window_bg_color #{if($variant == 'light', #fafafa, lighten(#181818, 8%))};
+@define-color window_fg_color #{if($variant=='light', '@dark_3', '@light_2')};
+
+// Views - e.g. text view or tree view
+@define-color view_bg_color #{if($variant == 'light', #ffffff, #1e1e1e)};
+@define-color view_fg_color #{if($variant == 'light', #000000, #ffffff)};
+
+// Header bar, search bar, tab bar
+@define-color headerbar_bg_color #{if($variant == 'light', #ebebeb, #303030)};
+@define-color headerbar_fg_color #{if($variant == 'light', transparentize(black, .2), white)};
+@define-color headerbar_backdrop_color @window_bg_color;
+
+// Cards, boxed lists
+@define-color card_bg_color #{if($variant == 'light', #ffffff, transparentize(white, .92))};
+@define-color card_fg_color #{if($variant == 'light', transparentize(black, .2), white)};
+
+// Popovers
+@define-color popover_bg_color #{if($variant == 'light', #ffffff, #383838)};
+@define-color popover_fg_color #{if($variant == 'light', transparentize(black, .2), white)};

--- a/themes/yaru-viridian/_functions.scss
+++ b/themes/yaru-viridian/_functions.scss
@@ -1,0 +1,16 @@
+@function gtkalpha($c,$a) {
+  @return unquote("alpha(#{$c},#{$a})");
+}
+
+@function gtkmix($c1,$c2,$r) {
+  $ratio: 1 -  $r / 100%; // match SCSS mix()
+  @return unquote("mix(#{$c1},#{$c2},#{$ratio})");
+}
+
+@function gtkshade($c,$s) {
+  @return unquote("shade(#{$c},#{$s})");
+}
+
+@function gtkcolor($c) {
+  @return unquote("@#{$c}");
+}

--- a/themes/yaru-viridian/_palette.scss
+++ b/themes/yaru-viridian/_palette.scss
@@ -1,0 +1,110 @@
+$blue_1: #75d3f4;
+$blue_2: #47c4f1;
+$blue_3: #19B6EE; // Yaru blue
+$blue_4: #007aa6; // Yaru linkblue
+$blue_5: #335280; // Yaru darkblue
+$green_1: #5AED70;
+$green_2: #47D35C;
+$green_3: #34B948;
+$green_4: #219E34;
+$green_5: #0e8420; // Yaru green
+$yellow_1: #FCCD87;
+$yellow_2: #FBC16A;
+$yellow_3: #FBB44C;
+$yellow_4: #FAA82F;
+$yellow_5: #F99B11; // Yaru yellow
+$orange_1: #F29879;
+$orange_2: #F08763;
+$orange_3: #ED764D;
+$orange_4: #EB6536;
+$orange_5: #E95420; // Yaru orange
+$red_1: #EA485C;
+$red_2: #DE374C;
+$red_3: #D3273B;
+$red_4: #c7162b; // Yaru red
+$red_5: #a91224;
+$purple_1: #924D8B; // Yaru aubergine
+$purple_2: #762572; // Yaru purple
+$purple_3: #77216F; // Yaru light aubergine
+$purple_4: #5E2750; // Yaru mid aubergine
+$purple_5: #2C001E; // Yaru dark aubergine
+$brown_1: #E1B289;
+$brown_2: #C5976E;
+$brown_3: #AA7B53;
+$brown_4: #8E6038;
+$brown_5: #72441D;
+$light_1: #FFFFFF;
+$light_2: #F7F7F7; // Yaru porcelain
+$light_3: #CCC; // Yaru silk
+$light_4: #AEA79F; // Yaru warm gray
+$light_5: #878787; // Yaru ash
+$dark_1: #666666; // Yaru graphite
+$dark_2: #5D5D5D; // Yaru slate
+$dark_3: #3D3D3D; // Yaru inkstone
+$dark_4: #181818; // Yaru jet
+$dark_5: #000000;
+
+// Ubuntu accent colors
+$default: $orange_5;
+$bark: #787859;
+$sage: #657B69;
+$olive: #4B8501;
+$viridian: #03875B;
+$prussiangreen: #308280;
+$blue: #0073E5;
+$purple: #7764D8;
+$magenta: #B34CB3;
+$red: #DA3450;
+
+$yaru_accent_bg_color: $viridian !default;
+@define-color yaru_accent_bg_color #{$yaru_accent_bg_color};
+
+
+// Sass thinks we're using the colors in the variables as strings and may shoot
+// warning, it's innocuous and can be defeated by using #{$var}.
+
+@define-color blue_1 #{$blue_1};
+@define-color blue_2 #{$blue_2};
+@define-color blue_3 #{$blue_3};
+@define-color blue_4 #{$blue_4};
+@define-color blue_5 #{$blue_5};
+@define-color green_1 #{$green_1};
+@define-color green_2 #{$green_2};
+@define-color green_3 #{$green_3};
+@define-color green_4 #{$green_4};
+@define-color green_5 #{$green_5};
+@define-color yellow_1 #{$yellow_1};
+@define-color yellow_2 #{$yellow_2};
+@define-color yellow_3 #{$yellow_3};
+@define-color yellow_4 #{$yellow_4};
+@define-color yellow_5 #{$yellow_5};
+@define-color orange_1 #{$orange_1};
+@define-color orange_2 #{$orange_2};
+@define-color orange_3 #{$orange_3};
+@define-color orange_4 #{$orange_4};
+@define-color orange_5 #{$orange_5};
+@define-color red_1 #{$red_1};
+@define-color red_2 #{$red_2};
+@define-color red_3 #{$red_3};
+@define-color red_4 #{$red_4};
+@define-color red_5 #{$red_5};
+@define-color purple_1 #{$purple_1};
+@define-color purple_2 #{$purple_2};
+@define-color purple_3 #{$purple_3};
+@define-color purple_4 #{$purple_4};
+@define-color purple_5 #{$purple_5};
+@define-color brown_1 #{$brown_1};
+@define-color brown_2 #{$brown_2};
+@define-color brown_3 #{$brown_3};
+@define-color brown_4 #{$brown_4};
+@define-color brown_5 #{$brown_5};
+@define-color light_1 #{$light_1};
+@define-color light_2 #{$light_2};
+@define-color light_3 #{$light_3};
+@define-color light_4 #{$light_4};
+@define-color light_5 #{$light_5};
+@define-color dark_1 #{$dark_1};
+@define-color dark_2 #{$dark_2};
+@define-color dark_3 #{$dark_3};
+@define-color dark_4 #{$dark_4};
+@define-color dark_5 #{$dark_5};

--- a/themes/yaru-viridian/_tweaks.scss
+++ b/themes/yaru-viridian/_tweaks.scss
@@ -1,0 +1,73 @@
+// Reducing the amount of the palette's background colors to two
+.sidebar {
+	background-color: $window_bg_color;
+}
+
+// Entries drown if drawn on widgets with $base_color
+// Fixing this at least for notebooks, since entries on tabs is a common pattern
+// Remove this when upstream makes entries have a light border in the dark theme
+@if $variant== "dark" {
+	notebook entry {
+			background-color: gtkmix($view_bg_color, black, 98%);
+	}
+}
+
+// Fix popover wiggling effect (see #2903)
+popover.menu {
+	check,
+	radio {
+			transition: none;
+	}
+}
+
+// Use our own palette for high and not empty levelbar
+levelbar {
+	> trough {
+			> block {
+					&.high,
+					&:not(.empty) {
+							background-color: $success_color;
+					}
+			}
+	}
+}
+
+// Green suggested buttons
+%button,
+button {
+	&.suggested-action {
+			color: $success_fg_color;
+
+			&,
+			&:checked {
+					&:not(.flat) {
+							background-color: $success_bg_color;
+					}
+			}
+	}
+
+	&.flat {
+			&.suggested-action {
+					color: $success_color;
+			}
+	}
+}
+
+splitbutton {
+	&.suggested-action {
+			> button, > menubutton > button {
+					color: $success_fg_color;
+	
+					&, &:checked {
+							background-color: $success_bg_color;
+					}
+			}
+	}
+}
+
+%button,
+button,
+%link,
+link {
+	font-weight: normal;
+}

--- a/themes/yaru-viridian/gtk-dark.scss
+++ b/themes/yaru-viridian/gtk-dark.scss
@@ -1,0 +1,13 @@
+// General guidelines:
+// - very unlikely you want to edit something else than _common.scss
+// - keep the number of defined colors to a minimum, use the color blending functions if
+//   you need a subtle shade
+// - if you need to inverse a color function use the @if directive to match for dark $variant
+
+$variant: 'dark';
+
+@import 'palette';
+@import 'defaults';
+@import 'functions';
+@import 'colors';
+@import 'tweaks';

--- a/themes/yaru-viridian/gtk.css
+++ b/themes/yaru-viridian/gtk.css
@@ -1,0 +1,117 @@
+@define-color yaru_accent_bg_color #03875B;
+@define-color blue_1 #75d3f4;
+@define-color blue_2 #47c4f1;
+@define-color blue_3 #19B6EE;
+@define-color blue_4 #007aa6;
+@define-color blue_5 #335280;
+@define-color green_1 #5AED70;
+@define-color green_2 #47D35C;
+@define-color green_3 #34B948;
+@define-color green_4 #219E34;
+@define-color green_5 #0e8420;
+@define-color yellow_1 #FCCD87;
+@define-color yellow_2 #FBC16A;
+@define-color yellow_3 #FBB44C;
+@define-color yellow_4 #FAA82F;
+@define-color yellow_5 #F99B11;
+@define-color orange_1 #F29879;
+@define-color orange_2 #F08763;
+@define-color orange_3 #ED764D;
+@define-color orange_4 #EB6536;
+@define-color orange_5 #E95420;
+@define-color red_1 #EA485C;
+@define-color red_2 #DE374C;
+@define-color red_3 #D3273B;
+@define-color red_4 #c7162b;
+@define-color red_5 #a91224;
+@define-color purple_1 #924D8B;
+@define-color purple_2 #762572;
+@define-color purple_3 #77216F;
+@define-color purple_4 #5E2750;
+@define-color purple_5 #2C001E;
+@define-color brown_1 #E1B289;
+@define-color brown_2 #C5976E;
+@define-color brown_3 #AA7B53;
+@define-color brown_4 #8E6038;
+@define-color brown_5 #72441D;
+@define-color light_1 #FFFFFF;
+@define-color light_2 #F7F7F7;
+@define-color light_3 #CCC;
+@define-color light_4 #AEA79F;
+@define-color light_5 #878787;
+@define-color dark_1 #666666;
+@define-color dark_2 #5D5D5D;
+@define-color dark_3 #3D3D3D;
+@define-color dark_4 #181818;
+@define-color dark_5 #000000;
+/* GTK NAMED COLORS
+   ----------------
+   use responsibly! */
+@define-color accent_bg_color @yaru_accent_bg_color;
+@define-color accent_fg_color @light_1;
+@define-color accent_color @yaru_accent_bg_color;
+@define-color destructive_bg_color @red_4;
+@define-color destructive_fg_color @light_1;
+@define-color destructive_color @red_4;
+@define-color success_bg_color @green_4;
+@define-color success_fg_color @light_1;
+@define-color success_color @green_4;
+@define-color warning_bg_color @yellow_5;
+@define-color warning_fg_color @light_1;
+@define-color warning_color @yellow_5;
+@define-color error_bg_color @red_4;
+@define-color error_fg_color @light_1;
+@define-color error_color @red_4;
+@define-color window_bg_color #fafafa;
+@define-color window_fg_color @dark_3;
+@define-color view_bg_color #ffffff;
+@define-color view_fg_color #000000;
+@define-color headerbar_bg_color #ebebeb;
+@define-color headerbar_fg_color rgba(0, 0, 0, 0.8);
+@define-color headerbar_backdrop_color @window_bg_color;
+@define-color card_bg_color #ffffff;
+@define-color card_fg_color rgba(0, 0, 0, 0.8);
+@define-color popover_bg_color #ffffff;
+@define-color popover_fg_color rgba(0, 0, 0, 0.8);
+.sidebar {
+  background-color: @window_bg_color;
+}
+
+popover.menu check,
+popover.menu radio {
+  transition: none;
+}
+
+levelbar > trough > block.high, levelbar > trough > block:not(.empty) {
+  background-color: @success_color;
+}
+
+
+button.suggested-action {
+  color: @success_fg_color;
+}
+
+
+button.suggested-action:not(.flat),
+button.suggested-action:checked:not(.flat) {
+  background-color: @success_bg_color;
+}
+
+
+button.flat.suggested-action {
+  color: @success_color;
+}
+
+splitbutton.suggested-action > button, splitbutton.suggested-action > menubutton > button {
+  color: @success_fg_color;
+}
+
+splitbutton.suggested-action > button, splitbutton.suggested-action > button:checked, splitbutton.suggested-action > menubutton > button, splitbutton.suggested-action > menubutton > button:checked {
+  background-color: @success_bg_color;
+}
+
+
+button,
+link {
+  font-weight: normal;
+}

--- a/themes/yaru-viridian/gtk.scss
+++ b/themes/yaru-viridian/gtk.scss
@@ -1,0 +1,14 @@
+// General guidelines:
+// - very unlikely you want to edit something else than _common.scss
+// - keep the number of defined colors to a minimum, use the color blending functions if
+//   you need a subtle shade
+// - if you need to inverse a color function use the @if directive to match for dark $variant
+
+$variant: 'light';
+
+@import 'palette';
+@import 'defaults';
+@import 'functions';
+@import 'colors';
+@import 'tweaks';
+

--- a/themes/yaru-viridian/parse-sass.sh
+++ b/themes/yaru-viridian/parse-sass.sh
@@ -1,0 +1,12 @@
+#! /bin/bash
+
+if [ ! "$(which sassc 2> /dev/null)" ]; then
+   echo sassc needs to be installed to generate the css.
+   exit 1
+fi
+
+SASSC_OPT="-M -t expanded"
+
+echo Generating the css...
+
+sassc $SASSC_OPT gtk.scss gtk.css


### PR DESCRIPTION
**PR**
-- **adds all remaining accents used in Ubuntu**

In order to get different accents anyone can follow these steps:

1. Duplicate Yaru and/or Yaru-dark directory
2. Edit line 59 in **_palette.scss**
```
$yaru_accent_bg_color: $orange_5 !default;
```
3. Replace the $orange variable with desired one or your color.
4. Run parse-sass.sh


Handy script for batch sass compilation if you have more than just one theme:

1. From repository directory run following script

```sh
#!/bin/bash
for path in themes/yaru-*/ ; do
    for file in $path* ; do
    	if [[ ${file} == *.sh ]]
	then
	   cd $path
	   echo "Running ${file}"
	   ./parse-sass.sh
	   echo $path
	   cd ../../
    	fi
    done;
done;
```

2. Havel all Yaru themes compiled.